### PR TITLE
Support stability flags in constraints

### DIFF
--- a/constraint_test.go
+++ b/constraint_test.go
@@ -557,3 +557,47 @@ func TestHyphenatedVersionRange(t *testing.T) {
 		}
 	}
 }
+
+func TestStabilityFlags(t *testing.T) {
+	tests := []struct {
+		constraint string
+		version    string
+		expected   bool
+	}{
+		{">=1.0.0@stable", "1.0.0-rc1", false},
+		{">=1.0.0@stable", "1.0.0", true},
+		{">=1.0.0@stable", "1.1.0", true},
+		{">=1.0.0@dev", "1.0.0-rc1", true},
+		{">=1.0.0@dev", "1.0.0", true},
+		{">=1.0.0@beta", "1.0.0-alpha1", false},
+		{">=1.0.0@beta", "1.0.0-beta1", true},
+		{">=1.0.0@beta", "1.0.0-rc1", true},
+		{">=1.0.0@beta", "1.0.0", true},
+		{">=1.0.0@rc", "1.0.0-beta", false},
+		{">=1.0.0@rc", "1.0.0-rc1", true},
+		{">=1.0.0@rc", "1.0.0", true},
+		{">=1.0.0@alpha", "1.0.0-dev", false},
+		{">=1.0.0@alpha", "1.0.0-alpha", true},
+		{">=1.0.0@alpha", "1.0.0-beta", true},
+	}
+
+	for _, tc := range tests {
+		c, err := NewConstraint(tc.constraint)
+		if err != nil {
+			t.Errorf("Failed to parse constraint %s: %v", tc.constraint, err)
+			continue
+		}
+
+		v := Must(NewVersion(tc.version))
+		actual := c.Check(v)
+		if actual != tc.expected {
+			t.Errorf("Constraint %s with version %s: expected %v, got %v", tc.constraint, tc.version, tc.expected, actual)
+		}
+	}
+}
+
+func TestUnknownStability(t *testing.T) {
+	if _, err := NewConstraint(">=1.0.0@foo"); err == nil {
+		t.Errorf("expected error for unknown stability")
+	}
+}


### PR DESCRIPTION
## Summary
- allow optional stability flags in constraint expressions
- skip versions below specified stability level
- test stability flag behavior including invalid flag handling

## Testing
- `go test ./...`
