### PR TITLE
feat: add constraint intersection/subset API and harden parsing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,18 +6,53 @@ on:
   pull_request:
     branches: [ "main" ]
 
-jobs:
+permissions:
+  contents: read
 
+jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+          check-latest: true
 
-    - name: Build
-      run: go build -v ./...
+      - name: Build
+        run: go build -v ./...
 
-    - name: Test
-      run: go test -v ./...
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test (race)
+        run: go test -race -v ./...
+
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+          check-latest: true
+
+      # Smoke-run each fuzz target for a short, bounded time. This re-checks the
+      # committed regression corpus under testdata/ and gives the fuzzer a brief
+      # window to surface new inputs on every push/PR without blowing up CI time.
+      - name: Fuzz smoke test
+        run: |
+          for target in \
+            FuzzNewVersion \
+            FuzzNormalizeComposerVersion \
+            FuzzNewConstraint \
+            FuzzSatisfies \
+            FuzzConstraintIntersects; do
+            echo "::group::$target"
+            go test -run '^$' -fuzz="^${target}$" -fuzztime=20s .
+            echo "::endgroup::"
+          done

--- a/api.go
+++ b/api.go
@@ -1,0 +1,54 @@
+package version
+
+import "strings"
+
+const (
+	StabilityDev    = "dev"
+	StabilityAlpha  = "alpha"
+	StabilityBeta   = "beta"
+	StabilityRC     = "RC"
+	StabilityStable = "stable"
+)
+
+// Satisfies reports whether versionString matches constraintString.
+func Satisfies(versionString, constraintString string) (bool, error) {
+	v, err := NewVersion(versionString)
+	if err != nil {
+		return false, err
+	}
+
+	constraintString = strings.TrimSpace(constraintString)
+	if constraintString == "" || constraintString == "*" {
+		return true, nil
+	}
+
+	constraint, err := NewConstraint(constraintString)
+	if err != nil {
+		return false, err
+	}
+
+	return constraint.Check(v), nil
+}
+
+// NormalizeComposerVersion normalizes a Composer version string for comparison.
+func NormalizeComposerVersion(versionString string) (string, error) {
+	return normalizeVersion(versionString)
+}
+
+// Stability returns the Composer stability for a version string.
+func Stability(versionString string) string {
+	v, err := NewVersion(versionString)
+	if err != nil {
+		normalized, normalizeErr := normalizeVersion(versionString)
+		if normalizeErr == nil && strings.HasPrefix(strings.ToLower(normalized), "dev-") {
+			return StabilityDev
+		}
+		return StabilityDev
+	}
+
+	stability := getVersionStability(v)
+	if stability == "rc" {
+		return StabilityRC
+	}
+	return stability
+}

--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,67 @@
+package version
+
+import "testing"
+
+func TestSatisfies(t *testing.T) {
+	tests := []struct {
+		version    string
+		constraint string
+		expected   bool
+	}{
+		{"6.4.28", ">=6.4.0,<6.4.29", true},
+		{"6.4.29", ">=6.4.0,<6.4.29", false},
+		{"1.2.3", "", true},
+		{"1.2.3", "*", true},
+	}
+
+	for _, tc := range tests {
+		actual, err := Satisfies(tc.version, tc.constraint)
+		if err != nil {
+			t.Errorf("Satisfies(%q, %q) unexpected error: %v", tc.version, tc.constraint, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("Satisfies(%q, %q): expected %v, got %v", tc.version, tc.constraint, tc.expected, actual)
+		}
+	}
+}
+
+func TestSatisfiesErrors(t *testing.T) {
+	if _, err := Satisfies("not-a-version", "*"); err == nil {
+		t.Fatal("expected invalid version error")
+	}
+	if _, err := Satisfies("1.2.3", ">>1.0"); err == nil {
+		t.Fatal("expected malformed constraint error")
+	}
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	normalized, err := normalizeVersion("v1.2.3")
+	if err != nil {
+		t.Fatalf("unexpected normalize error: %v", err)
+	}
+	if normalized != "1.2.3.0" {
+		t.Fatalf("expected 1.2.3.0, got %s", normalized)
+	}
+}
+
+func TestStability(t *testing.T) {
+	tests := []struct {
+		version  string
+		expected string
+	}{
+		{"dev-main", StabilityDev},
+		{"1.x-dev", StabilityDev},
+		{"1.2.0-alpha1", StabilityAlpha},
+		{"1.2.0-beta2", StabilityBeta},
+		{"1.2.0-RC1", StabilityRC},
+		{"1.2.0", StabilityStable},
+	}
+
+	for _, tc := range tests {
+		actual := Stability(tc.version)
+		if actual != tc.expected {
+			t.Errorf("Stability(%q): expected %q, got %q", tc.version, tc.expected, actual)
+		}
+	}
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,143 @@
+package version
+
+import "testing"
+
+// Representative inputs spanning the parser's distinct paths: short/full
+// semver, prereleases, the v-prefix, dev branches, and date-style versions.
+var benchVersions = []string{
+	"1.2.3",
+	"1.2.3.4",
+	"v2.0.0",
+	"1.0.0-beta.5",
+	"1.0.0-alpha1",
+	"2.1.x-dev",
+	"dev-main",
+	"20100102",
+	"1.2.3+build.123",
+}
+
+var benchConstraints = []string{
+	"1.2.3",
+	"^1.0",
+	"~1.2.3",
+	">=1.0,<2.0",
+	"1.2.*",
+	"^1.0 || ^2.0",
+	">=1.0@stable",
+	"1.0 - 2.0",
+}
+
+func BenchmarkNewVersion(b *testing.B) {
+	for _, v := range benchVersions {
+		b.Run(v, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := NewVersion(v); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkNormalizeComposerVersion(b *testing.B) {
+	for _, v := range benchVersions {
+		b.Run(v, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := NormalizeComposerVersion(v); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkNewConstraint(b *testing.B) {
+	for _, c := range benchConstraints {
+		b.Run(c, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := NewConstraint(c); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkCompare(b *testing.B) {
+	pairs := [][2]string{
+		{"1.2.3", "1.2.3"},        // equal fast path
+		{"1.2.3", "1.2.4"},        // differing segment
+		{"1.0.0-beta", "1.0.0"},   // prerelease vs stable
+		{"1.0.0-alpha", "1.0.0-beta"}, // prerelease ordering
+		{"1.2.3", "1.2.3.0"},      // jagged specificity
+	}
+	for _, p := range pairs {
+		left := Must(NewVersion(p[0]))
+		right := Must(NewVersion(p[1]))
+		b.Run(p[0]+"_vs_"+p[1], func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = left.Compare(right)
+			}
+		})
+	}
+}
+
+func BenchmarkConstraintCheck(b *testing.B) {
+	for _, c := range benchConstraints {
+		constraint, err := NewConstraint(c)
+		if err != nil {
+			b.Fatal(err)
+		}
+		v := Must(NewVersion("1.2.3"))
+		b.Run(c, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = constraint.Check(v)
+			}
+		})
+	}
+}
+
+// BenchmarkSatisfies measures the full parse-and-check path that most callers
+// actually use, including version and constraint parsing on every call.
+func BenchmarkSatisfies(b *testing.B) {
+	cases := [][2]string{
+		{"1.2.3", "^1.0"},
+		{"1.2.3", ">=1.0,<2.0"},
+		{"1.0.0-beta", "~1.0"},
+		{"2.5.0", "1.2.*"},
+	}
+	for _, tc := range cases {
+		b.Run(tc[0]+"_"+tc[1], func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := Satisfies(tc[0], tc[1]); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkConstraintIntersects(b *testing.B) {
+	cases := [][2]string{
+		{"^1.0", ">=1.0,<2.0"},
+		{"^6.4", ">=6.4.0,<6.4.29"},
+		{"1.2.*", ">=1.2.5,<1.3.0"},
+		{"^1.0 || ^2.0", "^1.5"},
+	}
+	for _, tc := range cases {
+		b.Run(tc[0]+"_"+tc[1], func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := ConstraintIntersects(tc[0], tc[1]); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/compare_parity_test.go
+++ b/compare_parity_test.go
@@ -1,0 +1,174 @@
+package version
+
+import "testing"
+
+// parityCorpus is a broad set of version strings spanning every parser path,
+// used to assert that the optimized comparison fast-path stays behaviorally
+// identical to the canonical NormalizedString-based comparison.
+var parityCorpus = []string{
+	"0", "1", "1.0", "1.2", "1.2.3", "1.2.3.4", "1.2.3.0",
+	"v1.2.3", "V2.0.0", "01.02.03", "000000", "00.00",
+	"1.0.0-dev", "1.0.0-alpha", "1.0.0-alpha1", "1.0.0-beta", "1.0.0-beta.5",
+	"1.0.0-rc1", "1.0.0-RC1", "1.0.0-patch1", "1.0.0-p1", "1.0.0-stable",
+	"1.0.0", "1.0.0.0", "1.2", "1.2.0", "1.2.0.0",
+	"20100102", "201903.0", "1.2.3+build.123", "1.0.0-beta+exp.sha",
+	"dev-main", "dev-master", "dev-feature/x", "2.1.x-dev",
+	"100000.00.0.00", "100000.0.0",
+}
+
+// referenceCompare replicates the pre-optimization Compare exactly (the
+// NormalizedString-string fast-path followed by the jagged, allZero-aware
+// segment loop). It is the behavioral oracle: the optimized Compare must return
+// the identical result for every pair, so the fast-path rewrite is provably
+// behavior-preserving rather than merely "matches NormalizedString".
+func referenceCompare(v, other *Version) int {
+	if v.NormalizedString() == other.NormalizedString() {
+		return 0
+	}
+	if v.branch != "" || other.branch != "" {
+		if v.branch == "" {
+			return 1
+		}
+		if other.branch == "" {
+			return -1
+		}
+		if v.branch < other.branch {
+			return -1
+		}
+		return 1
+	}
+	ss := v.Segments64()
+	so := other.Segments64()
+	eq := len(ss) == len(so)
+	if eq {
+		for i := range ss {
+			if ss[i] != so[i] {
+				eq = false
+				break
+			}
+		}
+	}
+	if eq {
+		preSelf := v.Prerelease()
+		preOther := other.Prerelease()
+		if preSelf == "" && preOther == "" {
+			return 0
+		}
+		if preSelf == "" {
+			if parsePrereleasePart(preOther).rank == prereleaseRankPatch {
+				return -1
+			}
+			return 1
+		}
+		if preOther == "" {
+			if parsePrereleasePart(preSelf).rank == prereleaseRankPatch {
+				return 1
+			}
+			return -1
+		}
+		return comparePrereleases(preSelf, preOther)
+	}
+	lenSelf := len(ss)
+	lenOther := len(so)
+	hS := lenSelf
+	if lenSelf < lenOther {
+		hS = lenOther
+	}
+	for i := 0; i < hS; i++ {
+		if i > lenSelf-1 {
+			if !allZero(so[i:]) {
+				return -1
+			}
+			break
+		} else if i > lenOther-1 {
+			if !allZero(ss[i:]) {
+				return 1
+			}
+			break
+		}
+		if ss[i] == so[i] {
+			continue
+		} else if ss[i] < so[i] {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+// TestCompareParity is the core safety net for the optimized Compare: it must
+// return the identical result to the reference (pre-optimization) implementation
+// for every pair in the corpus, including the 6-digit "date-like" segment edge
+// cases where NormalizedString and the jagged loop disagree.
+func TestCompareParity(t *testing.T) {
+	versions := make([]*Version, 0, len(parityCorpus))
+	for _, s := range parityCorpus {
+		v, err := NewVersion(s)
+		if err != nil {
+			t.Fatalf("seed %q failed to parse: %v", s, err)
+		}
+		versions = append(versions, v)
+	}
+
+	for i, a := range versions {
+		for j, b := range versions {
+			if got, want := a.Compare(b), referenceCompare(a, b); got != want {
+				t.Errorf("Compare(%q, %q) = %d, reference = %d",
+					parityCorpus[i], parityCorpus[j], got, want)
+			}
+		}
+	}
+}
+
+// TestCompareDevBranchReflexivity guards the trap that sank several rejected
+// optimization variants: dev branches all share pre="dev" and segments=[0,0,0],
+// so a naive segments+pre fast-path would treat distinct branches as equal.
+func TestCompareDevBranchReflexivity(t *testing.T) {
+	same := Must(NewVersion("dev-master"))
+	sameAgain := Must(NewVersion("dev-master"))
+	if same.Compare(sameAgain) != 0 {
+		t.Errorf("Compare(dev-master, dev-master) = %d, want 0", same.Compare(sameAgain))
+	}
+
+	foo := Must(NewVersion("dev-foo"))
+	bar := Must(NewVersion("dev-bar"))
+	if foo.Compare(bar) == 0 {
+		t.Error("Compare(dev-foo, dev-bar) == 0, want non-zero (distinct branches)")
+	}
+
+	// A branch and a numeric version must never be equal.
+	numeric := Must(NewVersion("0.0.0"))
+	if foo.Compare(numeric) == 0 {
+		t.Error("Compare(dev-foo, 0.0.0) == 0, want non-zero")
+	}
+}
+
+// TestNormalizedStringIdempotency pins the previously-uncovered idempotency
+// behavior so any future caching of NormalizedString cannot silently regress.
+func TestNormalizedStringIdempotency(t *testing.T) {
+	cases := map[string]string{
+		"000000":         "0.0.0.0",
+		"0":              "0.0.0.0",
+		"1.2":            "1.2.0.0",
+		"1.2.3":          "1.2.3.0",
+		"20100102":       "20100102", // date version: must NOT be padded
+		"v1.2.3":         "1.2.3.0",
+		"1.0.0-beta.5":   "1.0.0.0-beta5",
+	}
+	for input, want := range cases {
+		v, err := NewVersion(input)
+		if err != nil {
+			t.Errorf("NewVersion(%q) failed: %v", input, err)
+			continue
+		}
+		got := v.NormalizedString()
+		if got != want {
+			t.Errorf("NormalizedString(%q) = %q, want %q", input, got, want)
+		}
+		// Re-parsing the output must yield the same canonical form.
+		v2 := Must(NewVersion(got))
+		if v2.NormalizedString() != got {
+			t.Errorf("NormalizedString not idempotent for %q: %q -> %q", input, got, v2.NormalizedString())
+		}
+	}
+}

--- a/constraint.go
+++ b/constraint.go
@@ -2,7 +2,6 @@ package version
 
 import (
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 )
@@ -293,7 +292,7 @@ func (c *Constraint) Check(v *Version) bool {
 			return false
 		}
 	}
-	if c.stableBound && c.excludesSameVersionPrerelease() && v.IsPrerelease() && reflect.DeepEqual(v.Segments64(), c.check.Segments64()) {
+	if c.stableBound && c.excludesSameVersionPrerelease() && v.IsPrerelease() && equalInt64(v.segments, c.check.segments) {
 		return false
 	}
 	return c.f(v, c.check, c.origSegments)
@@ -724,7 +723,7 @@ func constraintGreaterThan(v, c *Version, origSegments int) bool {
 }
 
 func constraintLessThan(v, c *Version, origSegments int) bool {
-	if v.IsPrerelease() && !c.IsPrerelease() && reflect.DeepEqual(v.Segments64(), c.Segments64()) {
+	if v.IsPrerelease() && !c.IsPrerelease() && equalInt64(v.segments, c.segments) {
 		return false
 	}
 	return (bothNotPreRelease(v, c) || prereleaseCheck(v, c)) && v.LessThan(c)

--- a/constraint.go
+++ b/constraint.go
@@ -3,19 +3,20 @@ package version
 import (
 	"fmt"
 	"reflect"
-	"regexp"
+	"strconv"
 	"strings"
 )
 
 // Constraint represents a single constraint for a version, such as
 // ">= 1.0".
 type Constraint struct {
-	f         constraintFunc
-	check     *Version
-	original  string
-	stability string
-	origSegments int // Number of segments in the original constraint string
-	operator  string // The operator used (e.g., "~", "^", ">=", etc.)
+	f            constraintFunc
+	check        *Version
+	original     string
+	stability    string
+	origSegments int    // Number of segments in the original constraint string
+	operator     string // The operator used (e.g., "~", "^", ">=", etc.)
+	stableBound  bool
 }
 
 // Constraints is a 2D slice of constraints. We make a custom type so
@@ -25,7 +26,6 @@ type Constraints [][]*Constraint
 type constraintFunc func(v, c *Version, origSegments int) bool
 
 var (
-	constraintRegexp    *regexp.Regexp
 	constraintOperators map[string]constraintFunc
 	stabilityLevels     map[string]int
 )
@@ -41,7 +41,6 @@ func init() {
 		"<":  constraintLessThan,
 		">=": constraintGreaterThanEqual,
 		"<=": constraintLessThanEqual,
-		"~>": constraintPessimistic,
 		"^":  constraintCaret,
 		"~":  constraintTilde,
 		"*":  constraintWildcard,
@@ -55,24 +54,6 @@ func init() {
 		"stable": 4,
 	}
 
-	ops := []string{
-		"=",
-		"==",
-		"!=",
-		"<>",
-		">",
-		"<",
-		">=",
-		"<=",
-		"~>",
-		"\\^",
-		"~",
-		"",
-	}
-
-	constraintRegexp = regexp.MustCompile(fmt.Sprintf(
-		`^\s*(%s)\s*v?([0-9*]+(?:\.[0-9*]+)*(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?)(?:@([A-Za-z]+))?\s*$`,
-		strings.Join(ops, "|")))
 }
 
 // NewConstraint will parse one or more constraints from the given
@@ -83,53 +64,39 @@ func NewConstraint(cs string) (Constraints, error) {
 	ors := strings.Split(cs, "|")
 	or := make([][]*Constraint, len(ors))
 	for k, v := range ors {
+		v = stripConstraintAlias(v)
 		// Check for hyphenated range
-		if strings.Contains(v, " - ") {
-			parts := strings.Split(v, " - ")
-			if len(parts) != 2 {
-				return nil, fmt.Errorf("malformed constraint: %s", v)
-			}
-
-			// Create >= for the lower bound
-			lowerBound, err := parseSingle(">=" + strings.TrimSpace(parts[0]))
+		if strings.Contains(v, " - ") && !strings.Contains(v, ",") {
+			hyphenConstraints, err := parseHyphenRange(v)
 			if err != nil {
 				return nil, err
 			}
-
-			// Create <= for the upper bound
-			upperBound, err := parseSingle("<=" + strings.TrimSpace(parts[1]))
-			if err != nil {
-				return nil, err
-			}
-
-			or[k] = []*Constraint{lowerBound, upperBound}
+			or[k] = hyphenConstraints
 			continue
 		}
 
-		// Normalize spaces between constraints to comma
 		v = strings.TrimSpace(v)
-		// Replace spaces between constraints with commas, but preserve spaces in operator-version pairs
-		parts := strings.Fields(v)
-		var normalized []string
-		for i := 0; i < len(parts); i++ {
-			if isOperator(parts[i]) && i+1 < len(parts) {
-				normalized = append(normalized, parts[i]+parts[i+1])
-				i++
-			} else {
-				normalized = append(normalized, parts[i])
-			}
+		vs, err := splitAndConstraints(v)
+		if err != nil {
+			return nil, err
 		}
-		v = strings.Join(normalized, ",")
+		result := make([]*Constraint, 0, len(vs))
+		for _, single := range vs {
+			if strings.Contains(single, " - ") {
+				hyphenConstraints, err := parseHyphenRange(single)
+				if err != nil {
+					return nil, err
+				}
+				result = append(result, hyphenConstraints...)
+				continue
+			}
 
-		vs := strings.Split(v, ",")
-		result := make([]*Constraint, len(vs))
-		for i, single := range vs {
 			c, err := parseSingle(single)
 			if err != nil {
 				return nil, err
 			}
 
-			result[i] = c
+			result = append(result, c)
 		}
 		or[k] = result
 	}
@@ -137,10 +104,123 @@ func NewConstraint(cs string) (Constraints, error) {
 	return Constraints(or), nil
 }
 
+func parseHyphenRange(v string) ([]*Constraint, error) {
+	parts := strings.Split(v, " - ")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("malformed constraint: %s", v)
+	}
+	if invalidHyphenWildcard(strings.TrimSpace(parts[0])) || invalidHyphenWildcard(strings.TrimSpace(parts[1])) {
+		return nil, fmt.Errorf("malformed constraint: %s", v)
+	}
+
+	lowerBound, err := parseSingle(">=" + strings.TrimSpace(parts[0]))
+	if err != nil {
+		return nil, err
+	}
+
+	upperBound, err := parseHyphenUpperBound(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return nil, err
+	}
+
+	return []*Constraint{lowerBound, upperBound}, nil
+}
+
+func splitAndConstraints(v string) ([]string, error) {
+	commaParts := strings.Split(v, ",")
+	var result []string
+	for _, commaPart := range commaParts {
+		commaPart = strings.TrimSpace(commaPart)
+		if commaPart == "" {
+			return nil, fmt.Errorf("malformed constraint: %s", v)
+		}
+		if strings.Contains(commaPart, " - ") {
+			result = append(result, commaPart)
+			continue
+		}
+
+		fields := strings.Fields(commaPart)
+		for i := 0; i < len(fields); i++ {
+			if isOperator(fields[i]) && i+1 < len(fields) {
+				result = append(result, fields[i]+fields[i+1])
+				i++
+			} else {
+				result = append(result, fields[i])
+			}
+		}
+	}
+	return result, nil
+}
+
+func stripConstraintAlias(constraint string) string {
+	lower := strings.ToLower(constraint)
+	if index := strings.Index(lower, " as "); index >= 0 {
+		return strings.TrimSpace(constraint[:index])
+	}
+	return constraint
+}
+
+func parseHyphenUpperBound(v string) (*Constraint, error) {
+	parts, ok := simpleVersionParts(v)
+	if !ok || len(parts) >= 3 {
+		return parseSingle("<=" + v)
+	}
+
+	upper, err := incrementVersionParts(parts)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseSingle("<" + upper)
+}
+
+func invalidHyphenWildcard(v string) bool {
+	return isWildcardConstraintVersion(v) && !isNumericDevBranch(v)
+}
+
+func simpleVersionParts(v string) ([]string, bool) {
+	v = strings.TrimSpace(v)
+	if len(v) > 1 && (v[0] == 'v' || v[0] == 'V') {
+		v = v[1:]
+	}
+	if v == "" || strings.ContainsAny(v, "-+@*") {
+		return nil, false
+	}
+
+	parts := strings.Split(v, ".")
+	for _, part := range parts {
+		if part == "" {
+			return nil, false
+		}
+		if _, err := strconv.ParseInt(part, 10, 64); err != nil {
+			return nil, false
+		}
+	}
+
+	return parts, true
+}
+
+func incrementVersionParts(parts []string) (string, error) {
+	segments := make([]int64, len(parts))
+	for i, part := range parts {
+		segment, err := strconv.ParseInt(part, 10, 64)
+		if err != nil {
+			return "", err
+		}
+		segments[i] = segment
+	}
+
+	if len(segments) == 1 {
+		return fmt.Sprintf("%d.0.0", segments[0]+1), nil
+	}
+
+	return fmt.Sprintf("%d.%d.0", segments[0], segments[1]+1), nil
+}
+
 // isOperator checks if a string is a version constraint operator
 func isOperator(s string) bool {
 	_, ok := constraintOperators[s]
-	return ok || s == ">" || s == "<" || s == ">=" || s == "<=" || s == "!=" || s == "==" || s == "~>" || s == "~"
+	return ok || s == ">" || s == "<" || s == ">=" || s == "<=" || s == "!=" || s == "==" || s == "~"
 }
 
 // MustConstraints is a helper that wraps a call to a function
@@ -200,7 +280,32 @@ func (c *Constraint) Check(v *Version) bool {
 			return false
 		}
 	}
+	if c.check != nil && (v.branch != "" || c.check.branch != "") {
+		// Branch versions (dev-*) have no numeric ordering, so Composer only
+		// gives them meaning under the equality operators; an ordering operator
+		// applied to a branch matches nothing.
+		switch c.operator {
+		case "", "=", "==":
+			return v.Equal(c.check)
+		case "!=", "<>":
+			return !v.Equal(c.check)
+		default:
+			return false
+		}
+	}
+	if c.stableBound && c.excludesSameVersionPrerelease() && v.IsPrerelease() && reflect.DeepEqual(v.Segments64(), c.check.Segments64()) {
+		return false
+	}
 	return c.f(v, c.check, c.origSegments)
+}
+
+func (c *Constraint) excludesSameVersionPrerelease() bool {
+	switch c.operator {
+	case "", "=", "==", ">", ">=", "^", "~":
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *Constraint) String() string {
@@ -210,179 +315,380 @@ func (c *Constraint) String() string {
 func parseSingle(v string) (*Constraint, error) {
 	if strings.TrimSpace(v) == "*" {
 		return &Constraint{
-			f:        constraintWildcard,
-			check:    nil,
-			original: v,
+			f:            constraintWildcard,
+			check:        nil,
+			original:     v,
 			origSegments: 1,
-			operator: "*",
+			operator:     "*",
+		}, nil
+	}
+	if stability, ok := standaloneStabilityConstraint(v); ok {
+		return &Constraint{
+			f:            constraintWildcard,
+			check:        nil,
+			original:     v,
+			stability:    stability,
+			origSegments: 1,
+			operator:     "*",
 		}, nil
 	}
 
-	matches := constraintRegexp.FindStringSubmatch(v)
-	if matches == nil {
+	operator, version, stability, ok := splitConstraintParts(v)
+	if !ok {
 		return nil, fmt.Errorf("malformed constraint: %s", v)
 	}
 
-	operator := matches[1]
-	version := matches[2]
-	stability := ""
-	if len(matches) > 3 && matches[3] != "" {
-		stability = strings.ToLower(matches[3])
+	if stability != "" {
 		if _, ok := stabilityLevels[stability]; !ok {
 			return nil, fmt.Errorf("unknown stability: %s", stability)
 		}
 	}
 
-	// Count the number of segments in the original version string
-	origSegments := 1
-	if version != "" {
-		origSegments = strings.Count(version, ".") + 1
+	// Composer strips the @stability flag from the constraint and discards it
+	// when it is "stable" (see VersionParser::parseConstraint). The remaining
+	// flags only influence the implicit prerelease suffix appended below, so a
+	// trailing "@stable" must behave exactly like no flag at all.
+	if stability == "stable" {
+		stability = ""
 	}
+
+	version, err := stripDevReference(version, v)
+	if err != nil {
+		return nil, err
+	}
+
+	version = normalizeConstraintVersionTypos(version)
+	version = applyStabilitySuffix(version, stability, operator)
+	origSegments := countVersionSegments(version)
+	stableBound := hasStableModifier(version)
 
 	// Handle wildcards in version numbers
-	if strings.Contains(version, "*") {
-		return parseWildcardConstraint(operator, version, v, stability)
+	if isWildcardConstraintVersion(version) && !isNumericDevBranch(version) {
+		return parseWildcardConstraint(operator, version, v, "")
 	}
 
-	check, err := NewVersion(matches[2])
+	check, err := NewVersion(version)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Constraint{
-		f:         constraintOperators[matches[1]],
-		check:     check,
-		original:  v,
-		stability: stability,
+		f:            constraintOperators[operator],
+		check:        check,
+		original:     v,
 		origSegments: origSegments,
-		operator:  matches[1],
+		operator:     operator,
+		stableBound:  stableBound,
 	}, nil
+}
+
+func normalizeConstraintVersionTypos(version string) string {
+	version = strings.TrimSpace(version)
+	version = strings.ReplaceAll(version, "..dev", "-dev")
+	version = strings.ReplaceAll(version, "..DEV", "-DEV")
+	version = strings.ReplaceAll(version, "-.dev", "-dev")
+	version = strings.ReplaceAll(version, "-.DEV", "-DEV")
+	version = strings.ReplaceAll(version, "_-dev", "-dev")
+	version = strings.ReplaceAll(version, "_-DEV", "-DEV")
+	return strings.TrimRight(version, ".")
+}
+
+func standaloneStabilityConstraint(raw string) (string, bool) {
+	s := strings.TrimSpace(raw)
+	if len(s) < 2 || s[0] != '@' || !allAlpha(s[1:]) {
+		return "", false
+	}
+	stability := strings.ToLower(s[1:])
+	if _, ok := stabilityLevels[stability]; !ok {
+		return "", false
+	}
+	return stability, true
+}
+
+func applyStabilitySuffix(version, stability, operator string) string {
+	if stability == "" || !operatorUsesStabilitySuffix(operator) || hasNormalizedPrerelease(version) {
+		return version
+	}
+	return version + "-" + stability
+}
+
+func operatorUsesStabilitySuffix(operator string) bool {
+	switch operator {
+	case ">", ">=", "<", "<=", "^", "~":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasNormalizedPrerelease(version string) bool {
+	normalized, err := normalizeVersion(version)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(normalized, "-")
+}
+
+func stripDevReference(version, original string) (string, error) {
+	index := strings.Index(version, "#")
+	if index < 0 {
+		return version, nil
+	}
+
+	base := version[:index]
+	if strings.HasPrefix(strings.ToLower(base), "dev-") || isNumericDevBranch(base) {
+		return base, nil
+	}
+
+	return "", fmt.Errorf("malformed constraint: %s", original)
+}
+
+func splitConstraintParts(raw string) (operator, version, stability string, ok bool) {
+	s := strings.TrimSpace(raw)
+	for _, op := range []string{"==", "!=", "<>", ">=", "<=", "^", "~", ">", "<", "="} {
+		if strings.HasPrefix(s, op) {
+			operator = op
+			s = strings.TrimSpace(s[len(op):])
+			break
+		}
+	}
+	if s == "" {
+		return "", "", "", false
+	}
+
+	if at := strings.LastIndex(s, "@"); at > 0 && at < len(s)-1 && allAlpha(s[at+1:]) {
+		stability = strings.ToLower(s[at+1:])
+		s = strings.TrimSpace(s[:at])
+	}
+	if s == "" {
+		return "", "", "", false
+	}
+
+	if _, ok := constraintOperators[operator]; !ok {
+		return "", "", "", false
+	}
+
+	return operator, s, stability, true
+}
+
+func allAlpha(s string) bool {
+	for _, r := range s {
+		if (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') {
+			return false
+		}
+	}
+	return true
+}
+
+func hasStableModifier(version string) bool {
+	version = strings.TrimSpace(version)
+	if i := strings.IndexAny(version, "+@"); i >= 0 {
+		version = version[:i]
+	}
+	lower := strings.ToLower(version)
+	return strings.HasSuffix(lower, "-stable") || strings.HasSuffix(lower, ".stable") || strings.HasSuffix(lower, "_stable")
+}
+
+func countVersionSegments(version string) int {
+	version = strings.TrimSpace(version)
+	if len(version) > 1 && (version[0] == 'v' || version[0] == 'V') {
+		version = version[1:]
+	}
+	if i := strings.IndexAny(version, "-+@"); i >= 0 {
+		version = version[:i]
+	}
+	if version == "" {
+		return 1
+	}
+	return strings.Count(version, ".") + 1
+}
+
+func isNumericDevBranch(version string) bool {
+	lower := strings.ToLower(strings.TrimSpace(version))
+	if !strings.HasSuffix(lower, "-dev") {
+		return false
+	}
+
+	base := strings.TrimSuffix(version, version[len(version)-4:])
+	if len(base) > 1 && (base[0] == 'v' || base[0] == 'V') {
+		base = base[1:]
+	}
+	parts := strings.Split(base, ".")
+	if len(parts) == 0 || len(parts) > 4 {
+		return false
+	}
+	seenWildcard := false
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		if isWildcardSegment(part) {
+			if seenWildcard {
+				return false
+			}
+			seenWildcard = true
+			continue
+		}
+		if seenWildcard {
+			return false
+		}
+		if _, err := strconv.ParseInt(part, 10, 64); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func isWildcardConstraintVersion(version string) bool {
+	base := strings.TrimSpace(version)
+	if len(base) > 1 && (base[0] == 'v' || base[0] == 'V') {
+		base = base[1:]
+	}
+	if i := strings.IndexAny(base, "-+"); i >= 0 {
+		base = base[:i]
+	}
+	for _, part := range strings.Split(base, ".") {
+		if isWildcardSegment(part) {
+			return true
+		}
+	}
+	return false
+}
+
+func isWildcardSegment(part string) bool {
+	return part == "*" || strings.EqualFold(part, "x")
 }
 
 // parseWildcardConstraint handles parsing of version constraints containing wildcards.
 // It validates the wildcard pattern and creates appropriate constraint functions.
 func parseWildcardConstraint(operator, version, original, stability string) (*Constraint, error) {
-	parts := strings.Split(version, ".")
-
-	// Check for malformed wildcard patterns
-	starCount := 0
-	for i, part := range parts {
-		if part == "*" {
-			starCount++
-			// Wildcard can only appear at the end
-			if i < len(parts)-1 {
-				return nil, fmt.Errorf("malformed constraint: %s", original)
-			}
-		}
+	version = strings.TrimSpace(version)
+	if len(version) > 1 && (version[0] == 'v' || version[0] == 'V') {
+		version = version[1:]
 	}
-	if starCount > 1 {
+	if operator == "^" || operator == "~" {
+		return nil, fmt.Errorf("malformed constraint: %s", original)
+	}
+	if strings.ContainsAny(version, "-+") {
 		return nil, fmt.Errorf("malformed constraint: %s", original)
 	}
 
-	if len(parts) >= 2 && parts[1] == "*" {
-		// Convert 2.* to check for major version match
-		majorVersion := parts[0]
-		if strings.Contains(majorVersion, "*") {
+	parts := strings.Split(version, ".")
+	wildcardIndex := -1
+	fixed := []int64{}
+	for i, part := range parts {
+		if part == "" {
 			return nil, fmt.Errorf("malformed constraint: %s", original)
 		}
-		check, err := NewVersion(majorVersion + ".0.0")
-		if err != nil {
-			return nil, err
+		if isWildcardSegment(part) {
+			if wildcardIndex == -1 {
+				wildcardIndex = i
+			}
+			continue
 		}
-
-		return &Constraint{
-			f: func(v, c *Version, origSegments int) bool {
-				switch operator {
-				case ">=":
-					return v.segments[0] >= c.segments[0]
-				case ">":
-					return v.segments[0] > c.segments[0]
-				case "<=":
-					return v.segments[0] <= c.segments[0]
-				case "<":
-					return v.segments[0] < c.segments[0]
-				case "", "=", "==":
-					return v.segments[0] == c.segments[0]
-				case "!=", "<>":
-					return v.segments[0] != c.segments[0]
-				default:
-					return v.segments[0] == c.segments[0]
-				}
-			},
-			check:     check,
-			original:  original,
-			stability: stability,
-			operator:  operator,
-			origSegments: 2, // wildcard constraints don't use origSegments
-		}, nil
-	} else if len(parts) >= 3 && parts[2] == "*" {
-		// Convert 2.0.* to check for major.minor version match
-		majorMinor := parts[0] + "." + parts[1]
-		if strings.Contains(majorMinor, "*") {
+		if wildcardIndex != -1 {
 			return nil, fmt.Errorf("malformed constraint: %s", original)
 		}
-		check, err := NewVersion(majorMinor + ".0")
+		segment, err := strconv.ParseInt(part, 10, 64)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("malformed constraint: %s", original)
 		}
+		fixed = append(fixed, segment)
+	}
 
+	if wildcardIndex == -1 {
+		return nil, fmt.Errorf("malformed constraint: %s", original)
+	}
+
+	if len(fixed) == 0 {
+		if operator != "" && operator != "=" && operator != "==" {
+			return nil, fmt.Errorf("malformed constraint: %s", original)
+		}
+		if strings.TrimSpace(original) != "*" {
+			check, err := NewVersion("0.0.0-dev")
+			if err != nil {
+				return nil, err
+			}
+			return &Constraint{
+				f:            constraintGreaterThanEqual,
+				check:        check,
+				original:     original,
+				stability:    stability,
+				operator:     ">=",
+				origSegments: 1,
+			}, nil
+		}
 		return &Constraint{
-			f: func(v, c *Version, origSegments int) bool {
-				// First check major version
-				if v.segments[0] != c.segments[0] {
-					switch operator {
-					case ">=":
-						return v.segments[0] > c.segments[0]
-					case ">":
-						return v.segments[0] > c.segments[0]
-					case "<=":
-						return v.segments[0] < c.segments[0]
-					case "<":
-						return v.segments[0] < c.segments[0]
-					case "", "=", "==":
-						return false
-					case "!=", "<>":
-						return true
-					default:
-						return false
-					}
-				}
-
-				// If major version matches, check minor version
-				switch operator {
-				case ">=":
-					return v.segments[1] >= c.segments[1]
-				case ">":
-					return v.segments[1] > c.segments[1]
-				case "<=":
-					return v.segments[1] <= c.segments[1]
-				case "<":
-					return v.segments[1] < c.segments[1]
-				case "", "=", "==":
-					return v.segments[1] == c.segments[1]
-				case "!=", "<>":
-					return v.segments[1] != c.segments[1]
-				default:
-					return v.segments[1] == c.segments[1]
-				}
-			},
-			check:     check,
-			original:  original,
-			stability: stability,
-			operator:  operator,
-			origSegments: 3, // wildcard constraints don't use origSegments
+			f:            constraintWildcard,
+			check:        nil,
+			original:     original,
+			stability:    stability,
+			operator:     operator,
+			origSegments: 1,
 		}, nil
 	}
 
-	return nil, fmt.Errorf("malformed constraint: %s", original)
+	checkParts := make([]string, len(fixed))
+	for i, segment := range fixed {
+		checkParts[i] = strconv.FormatInt(segment, 10)
+	}
+	for len(checkParts) < 3 {
+		checkParts = append(checkParts, "0")
+	}
+	check, err := NewVersion(strings.Join(checkParts, "."))
+	if err != nil {
+		return nil, err
+	}
+
+	fixedLen := len(fixed)
+	return &Constraint{
+		f: func(v, c *Version, origSegments int) bool {
+			cmp := comparePrefix(v.segments, c.segments[:fixedLen])
+			switch operator {
+			case ">=":
+				return cmp >= 0
+			case ">":
+				return cmp > 0
+			case "<=":
+				return cmp <= 0
+			case "<":
+				return cmp < 0
+			case "!=", "<>":
+				return cmp != 0
+			default:
+				return cmp == 0
+			}
+		},
+		check:        check,
+		original:     original,
+		stability:    stability,
+		operator:     operator,
+		origSegments: fixedLen + 1,
+	}, nil
+}
+
+func comparePrefix(versionSegments, prefix []int64) int {
+	for i, expected := range prefix {
+		if i >= len(versionSegments) {
+			if expected == 0 {
+				continue
+			}
+			return -1
+		}
+		if versionSegments[i] < expected {
+			return -1
+		}
+		if versionSegments[i] > expected {
+			return 1
+		}
+	}
+	return 0
 }
 
 func prereleaseCheck(v, c *Version) bool {
 	switch vPre, cPre := v.Prerelease() != "", c.Prerelease() != ""; {
 	case cPre && vPre:
-		// A constraint with a pre-release can only match a pre-release version
-		// with the same base segments.
-		return reflect.DeepEqual(c.Segments64(), v.Segments64())
+		return true
 
 	case !cPre && vPre:
 		// A constraint without a pre-release can match a version with a
@@ -414,11 +720,14 @@ func constraintNotEqual(v, c *Version, origSegments int) bool {
 }
 
 func constraintGreaterThan(v, c *Version, origSegments int) bool {
-	return (bothNotPreRelease(v, c) || prereleaseCheck(v, c)) && v.Compare(c) == 1
+	return (bothNotPreRelease(v, c) || prereleaseCheck(v, c)) && v.GreaterThan(c)
 }
 
 func constraintLessThan(v, c *Version, origSegments int) bool {
-	return (bothNotPreRelease(v, c) || prereleaseCheck(v, c)) && v.Compare(c) == -1
+	if v.IsPrerelease() && !c.IsPrerelease() && reflect.DeepEqual(v.Segments64(), c.Segments64()) {
+		return false
+	}
+	return (bothNotPreRelease(v, c) || prereleaseCheck(v, c)) && v.LessThan(c)
 }
 
 func constraintGreaterThanEqual(v, c *Version, origSegments int) bool {
@@ -436,82 +745,47 @@ func constraintGreaterThanEqual(v, c *Version, origSegments int) bool {
 		return vNoPrerelease.Compare(cNoPrerelease) >= 0
 	}
 
-	return (bothNotPreRelease(v, c) || prereleaseCheck(v, c)) && v.Compare(c) >= 0
+	return (bothNotPreRelease(v, c) || prereleaseCheck(v, c)) && v.GreaterThanOrEqual(c)
 }
 
 func constraintLessThanEqual(v, c *Version, origSegments int) bool {
-	return (bothNotPreRelease(v, c) || prereleaseCheck(v, c)) && v.Compare(c) <= 0
-}
-
-func constraintPessimistic(v, c *Version, origSegments int) bool {
-	// Using a pessimistic constraint with a pre-release, restricts versions to pre-releases
-	if !prereleaseCheck(v, c) || (c.Prerelease() != "" && v.Prerelease() == "") {
-		return false
-	}
-
-	// If the version being checked is naturally less than the constraint, then there
-	// is no way for the version to be valid against the constraint
-	if v.LessThan(c) {
-		return false
-	}
-	// We'll use this more than once, so grab the length now so it's a little cleaner
-	// to write the later checks
-	cs := len(c.segments)
-
-	// If the version being checked has less specificity than the constraint, then there
-	// is no way for the version to be valid against the constraint
-	if cs > len(v.segments) {
-		return false
-	}
-
-	// Check the segments in the constraint against those in the version. If the version
-	// being checked, at any point, does not have the same values in each index of the
-	// constraints segments, then it cannot be valid against the constraint.
-	for i := 0; i < c.si-1; i++ {
-		if v.segments[i] != c.segments[i] {
-			return false
-		}
-	}
-
-	// Check the last part of the segment in the constraint. If the version segment at
-	// this index is less than the constraints segment at this index, then it cannot
-	// be valid against the constraint
-	return c.segments[cs-1] <= v.segments[cs-1]
+	return (bothNotPreRelease(v, c) || prereleaseCheck(v, c)) && v.LessThanOrEqual(c)
 }
 
 func constraintCaret(v, c *Version, origSegments int) bool {
-	// For pre-release versions, we need to check if they match the constraint
+	compareVersion := v
+	compareConstraint := c
+
 	if v.IsPrerelease() && !c.IsPrerelease() {
-		// Compare without pre-release info first
-		vNoPrerelease := &Version{
+		compareVersion = &Version{
 			segments: v.segments,
 			si:       v.si,
 		}
-		cNoPrerelease := &Version{
+		compareConstraint = &Version{
 			segments: c.segments,
 			si:       c.si,
 		}
-		if vNoPrerelease.LessThan(cNoPrerelease) {
-			return false
-		}
-		if vNoPrerelease.segments[0] != cNoPrerelease.segments[0] {
-			return false
-		}
-		return true
 	}
 
 	// If the version being checked is naturally less than the constraint, then there
 	// is no way for the version to be valid against the constraint
-	if v.LessThan(c) {
+	if compareVersion.LessThan(compareConstraint) {
 		return false
 	}
 
-	// Check the major version
-	if v.segments[0] != c.segments[0] {
-		return false
+	if c.segments[0] != 0 {
+		return v.segments[0] == c.segments[0]
 	}
 
-	return true
+	if origSegments <= 1 {
+		return v.segments[0] == 0
+	}
+
+	if c.segments[1] != 0 || origSegments <= 2 {
+		return v.segments[0] == 0 && v.segments[1] == c.segments[1]
+	}
+
+	return v.segments[0] == 0 && v.segments[1] == 0 && v.segments[2] == c.segments[2]
 }
 
 func constraintTilde(v, c *Version, origSegments int) bool {
@@ -525,10 +799,16 @@ func constraintTilde(v, c *Version, origSegments int) bool {
 		si:       c.si,
 	}
 
-	// If the version without prerelease is less than the constraint without prerelease,
-	// then there is no way for the version to be valid against the constraint
-	if vNoPrerelease.LessThan(cNoPrerelease) {
-		return false
+	if c.IsPrerelease() {
+		if v.LessThan(c) {
+			return false
+		}
+	} else {
+		// If the version without prerelease is less than the constraint without prerelease,
+		// then there is no way for the version to be valid against the constraint
+		if vNoPrerelease.LessThan(cNoPrerelease) {
+			return false
+		}
 	}
 
 	// Check the major version
@@ -539,9 +819,14 @@ func constraintTilde(v, c *Version, origSegments int) bool {
 	// Tilde constraint behavior in Composer:
 	// ~X.Y.Z (3 segments) allows patch-level changes: >=X.Y.Z <X.(Y+1).0
 	// ~X.Y (2 segments) allows minor-level changes: >=X.Y.0 <(X+1).0.0
-	
-	// For constraints with 3+ segments (~X.Y.Z), minor version must match
-	if origSegments >= 3 {
+
+	// For constraints with 4+ segments (~X.Y.Z.W), patch version must match.
+	if origSegments >= 4 {
+		if v.segments[1] != c.segments[1] || v.segments[2] != c.segments[2] {
+			return false
+		}
+	} else if origSegments >= 3 {
+		// For constraints with 3 segments (~X.Y.Z), minor version must match.
 		if v.segments[1] != c.segments[1] {
 			return false
 		}
@@ -549,17 +834,11 @@ func constraintTilde(v, c *Version, origSegments int) bool {
 	// For constraints with 2 segments (~X.Y), only major version must match
 	// (already checked above)
 
-	// For tilde operator, we allow any prerelease version
-	// as long as the major and minor versions match
-	if v.IsPrerelease() && !c.IsPrerelease() {
-		return true
-	}
-
-	// For exact version matches, we need to check prereleases
-	if c.si == len(v.segments) && reflect.DeepEqual(v.segments[:c.si], c.segments[:c.si]) {
-		return prereleaseCheck(v, c)
-	}
-
+	// Composer compiles ~X.Y.Z into >=X.Y.Z(-dev) <upper, so the implicit
+	// lower bound carries dev stability and prereleases that share the base
+	// segments (e.g. 1.2.3-beta for ~1.2.3) are in range. The only exclusion
+	// is for explicitly stable constraints, which Check() applies centrally
+	// via stableBound. The lower and upper bounds were already enforced above.
 	return true
 }
 
@@ -585,6 +864,8 @@ func getVersionStability(v *Version) string {
 		return "beta"
 	case strings.HasPrefix(pre, "rc"):
 		return "rc"
+	case strings.HasPrefix(pre, "patch") || strings.HasPrefix(pre, "p"):
+		return "stable"
 	default:
 		return "dev"
 	}

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -87,6 +87,66 @@ func TestConstraints(t *testing.T) {
 	MustConstraints(NewConstraint(">=1.0.0,<2.0.0"))
 }
 
+func TestSemverSatisfiesFixtures(t *testing.T) {
+	// Selected fixtures adapted from external semver behavior.
+	tests := []struct {
+		version    string
+		constraint string
+		expected   bool
+	}{
+		{"1.2.3", "1.0.0 - 2.0.0", true},
+		{"1.2.3", "^1.2.3+build", true},
+		{"1.3.0", "^1.2.3+build", true},
+		{"2.4.3-alpha", "1.2.3+asdf - 2.4.3+asdf", true},
+		{"1.3.0-beta", ">1.2", true},
+		{"1.2.3-beta", "<=1.2.3", true},
+		{"1.2.3-beta", "^1.2.3", true},
+		{"1.0.0", ">= 1", true},
+		{"1.2.8", ">1.2", true},
+		{"1.1.1", "< 1.2", true},
+		{"1.2.3", "~1.2.1 >=1.2.3", true},
+		{"1.2.3", "~1.2.1 1.2.3", true},
+		{"1.8.1", "^1.2.3", true},
+		{"0.1.2", "^0.1.2", true},
+		{"0.1.2", "^0.1", true},
+		{"0.0.1-beta", "^0.0.1-alpha", true},
+		{"2.2.3", "1.0.0 - 2.0.0", false},
+		{"2.0.0", "^1.2.3+build", false},
+		{"1.2.0", "^1.2.3+build", false},
+		{"1.0.1", "1.0.0", false},
+		{"0.0.0", ">=1.0.0", false},
+		{"0.0.1", ">1.0.0", false},
+		{"3.0.0", "<=2.0.0", false},
+		{"2.2.9", "<2.0.0", false},
+		{"2.4.1", "2.3", false},
+		{"3.0.0", "~2.4", false},
+		{"2.3.9", "~2.4", false},
+		{"0.2.3", "~1", false},
+		{"2.0.0-alpha", "^1.2.3", false},
+		{"1.2.2", "^1.2.3", false},
+		{"1.1.9", "^1.2", false},
+	}
+
+	for _, tc := range tests {
+		c, err := NewConstraint(tc.constraint)
+		if err != nil {
+			t.Errorf("Failed to parse constraint %s: %v", tc.constraint, err)
+			continue
+		}
+
+		v, err := NewVersion(tc.version)
+		if err != nil {
+			t.Errorf("Failed to parse version %s: %v", tc.version, err)
+			continue
+		}
+
+		actual := c.Check(v)
+		if actual != tc.expected {
+			t.Errorf("Constraint %s with version %s: expected %v, got %v", tc.constraint, tc.version, tc.expected, actual)
+		}
+	}
+}
+
 func TestConstraintParsingWhitespaceAnd(t *testing.T) {
 	c, err := NewConstraint(">=1.0 <2.0")
 	if err != nil {
@@ -188,6 +248,11 @@ func TestPrereleaseConstraints(t *testing.T) {
 		{"<=1.0.0", "1.0.0-alpha", true},
 		{"^1.0.0", "1.1.0-alpha", true},
 		{"~1.0.0", "1.0.1-beta", true},
+		// A tilde constraint with a prerelease lower bound still matches the
+		// equal stable release, which sorts above the prerelease.
+		{"~1.2.2-dev", "1.2.2", true},
+		{"~1.2.3-alpha", "1.2.3", true},
+		{"~2.1.0-dev", "2.1.0", true},
 	}
 
 	for _, tc := range tests {
@@ -212,11 +277,15 @@ func TestCaretOperatorEdgeCases(t *testing.T) {
 		expected   bool
 	}{
 		{"^0.1.0", "0.1.0", true},
-		{"^0.1.0", "0.2.0", true},
+		{"^0.1.0", "0.1.99", true},
+		{"^0.1.0", "0.2.0", false},
+		{"^0.3", "0.3.99", true},
+		{"^0.3", "0.4.0", false},
 		{"^1.0.0", "2.0.0", false},
 		{"^1.0.0", "1.9.9", true},
 		{"^1.0.0-alpha", "1.0.0-beta", true},
-		{"^0.0.1", "0.0.2", true},
+		{"^0.0.1", "0.0.1", true},
+		{"^0.0.1", "0.0.2", false},
 		{"^0.0.1", "0.0.1-alpha", true},
 	}
 
@@ -277,6 +346,9 @@ func TestMalformedConstraints(t *testing.T) {
 		"!1.0.0",
 		"1.0.0-",
 		"~>1.a.0",
+		// Composer has no "~>" operator (that is rubygems syntax); it must be rejected.
+		"~>2.1.0",
+		"~> 2.1.0",
 		">=1.0.0-",
 		"^1.0.0-",
 		"~1.0.0-",
@@ -507,6 +579,14 @@ func TestWildcardWithOperators(t *testing.T) {
 		{"2.0.*", "2.0.0-alpha", true},
 		{"2.0.*", "2.0.5-beta", true},
 		{"2.0.*", "2.1.0-alpha", false},
+		{"2.x.x", "2.1.3", true},
+		{"2.x.x", "1.1.3", false},
+		{"1.2.x", "1.2.3", true},
+		{"1.2.x", "1.3.3", false},
+		{"x", "1.2.3", true},
+		{"2.*.*", "2.1.3", true},
+		{"2.*.*", "1.1.3", false},
+		{"*.*", "1.2.3", true},
 	}
 
 	for _, tc := range tests {
@@ -520,10 +600,8 @@ func TestWildcardWithOperators(t *testing.T) {
 
 func TestMalformedWildcardConstraints(t *testing.T) {
 	malformed := []string{
-		"2.*.*",
 		"*.0.0",
 		"2.*.0",
-		"*.*",
 		"2.*.5",
 		">=*",
 		">=*.0",
@@ -543,8 +621,13 @@ func TestHyphenatedVersionRange(t *testing.T) {
 		version    string
 		expected   bool
 	}{
+		{"1.0 - 2.0", "1.5.0", true},
+		{"1.0 - 2.0", "2.0.0", true},
+		{"1.0 - 2.0", "2.0.9", true},
+		{"1.0 - 2.0", "2.1.0", false},
 		{"1.0.0 - 2.0.0", "1.0.0-alpha", true},
 		{"1.0.0 - 2.0.0", "2.0.0-alpha", true},
+		{"1.0.0 - 2.0.0", "2.0.1", false},
 		{"1.0.0 - 2.0.0", "0.9.9", false},
 		{"1.0.0 - 2.0.0", "3.0.0", false},
 	}
@@ -570,7 +653,9 @@ func TestStabilityFlags(t *testing.T) {
 		version    string
 		expected   bool
 	}{
-		{">=1.0.0@stable", "1.0.0-rc1", false},
+		// Composer strips and discards the @stable flag, so these behave exactly
+		// like the flagless ">=1.0.0" and still accept same-version prereleases.
+		{">=1.0.0@stable", "1.0.0-rc1", true},
 		{">=1.0.0@stable", "1.0.0", true},
 		{">=1.0.0@stable", "1.1.0", true},
 		{">=1.0.0@dev", "1.0.0-rc1", true},
@@ -605,5 +690,70 @@ func TestStabilityFlags(t *testing.T) {
 func TestUnknownStability(t *testing.T) {
 	if _, err := NewConstraint(">=1.0.0@foo"); err == nil {
 		t.Errorf("expected error for unknown stability")
+	}
+}
+
+// TestStableFlagVsModifier pins down the difference between the "@stable" flag
+// (which Composer strips and discards) and an explicit "-stable" version
+// modifier (which Composer keeps). The flag must not raise the lower bound, so
+// it accepts same-version prereleases just like a flagless constraint; the
+// modifier must reject them.
+func TestStableFlagVsModifier(t *testing.T) {
+	tests := []struct {
+		constraint string
+		version    string
+		expected   bool
+	}{
+		{">=1.0@stable", "1.0.0-beta", true},
+		{">=1.0@stable", "1.0.0-alpha", true},
+		{">=1.0@stable", "1.0.0", true},
+		{">=1.0", "1.0.0-beta", true},
+		{">=1.0-stable", "1.0.0-beta", false},
+		{">=1.0-stable", "1.0.0", true},
+		{"^1.0@stable", "1.0.0-beta", true},
+		{"~1.0@stable", "1.0.0-beta", true},
+	}
+
+	for _, tc := range tests {
+		c, err := NewConstraint(tc.constraint)
+		if err != nil {
+			t.Errorf("Failed to parse constraint %s: %v", tc.constraint, err)
+			continue
+		}
+		actual := c.Check(Must(NewVersion(tc.version)))
+		if actual != tc.expected {
+			t.Errorf("Constraint %s with version %s: expected %v, got %v", tc.constraint, tc.version, tc.expected, actual)
+		}
+	}
+}
+
+func TestDevBranchConstraints(t *testing.T) {
+	tests := []struct {
+		constraint string
+		version    string
+		expected   bool
+	}{
+		{"dev-master", "dev-master", true},
+		{"dev-master", "dev-main", false},
+		{"dev-feature-a", "dev-feature-a", true},
+		{"!=dev-feature-a", "dev-feature-b", true},
+		{"1.0.x-dev", "1.0.9999999.9999999-dev", true},
+	}
+
+	for _, tc := range tests {
+		c, err := NewConstraint(tc.constraint)
+		if err != nil {
+			t.Errorf("Failed to parse constraint %s: %v", tc.constraint, err)
+			continue
+		}
+		v, err := NewVersion(tc.version)
+		if err != nil {
+			t.Errorf("Failed to parse version %s: %v", tc.version, err)
+			continue
+		}
+		actual := c.Check(v)
+		if actual != tc.expected {
+			t.Errorf("Constraint %s with version %s: expected %v, got %v", tc.constraint, tc.version, tc.expected, actual)
+		}
 	}
 }

--- a/domain.go
+++ b/domain.go
@@ -1,0 +1,451 @@
+package version
+
+import (
+	"strconv"
+	"strings"
+)
+
+// This file holds the constraint-domain model: the union-of-intervals plus
+// branch representation of a parsed constraint, and the operations that build,
+// intersect, and test subset relationships between domains.
+
+type constraintDomain struct {
+	numeric       []versionInterval
+	anyBranch     bool
+	branches      map[string]struct{}
+	branchExclude map[string]struct{}
+}
+
+func constraintsDomain(constraints []*Constraint) (constraintDomain, error) {
+	domain := allConstraintDomain()
+	for _, constraint := range constraints {
+		next, err := singleConstraintDomain(constraint)
+		if err != nil {
+			return constraintDomain{}, err
+		}
+		domain = intersectDomains(domain, next)
+		if domainEmpty(domain) {
+			return domain, nil
+		}
+	}
+	return domain, nil
+}
+
+func singleConstraintDomain(c *Constraint) (constraintDomain, error) {
+	if c.check == nil {
+		return allConstraintDomain(), nil
+	}
+
+	if c.check.branch != "" {
+		switch c.operator {
+		case "", "=", "==":
+			return branchOnlyDomain(c.check.branch), nil
+		case "!=", "<>":
+			domain := allConstraintDomain()
+			domain.branchExclude[c.check.branch] = struct{}{}
+			return domain, nil
+		default:
+			return constraintDomain{}, nil
+		}
+	}
+
+	if isConstraintWildcard(c) {
+		return wildcardConstraintDomain(c), nil
+	}
+
+	switch c.operator {
+	case "", "=", "==":
+		return numericOnlyDomain(versionInterval{
+			lower: inclusiveBound(c.check),
+			upper: inclusiveBound(c.check),
+		}), nil
+	case "!=",
+		"<>":
+		domain := allConstraintDomain()
+		domain.numeric[0].exclusions = append(domain.numeric[0].exclusions, c.check)
+		return domain, nil
+	case ">":
+		return numericOnlyDomain(versionInterval{lower: exclusiveBound(c.check)}), nil
+	case ">=":
+		return numericOnlyDomain(versionInterval{lower: inclusiveBound(implicitDevLowerBound(c))}), nil
+	case "<":
+		return numericOnlyDomain(versionInterval{upper: exclusiveBound(implicitDevUpperBound(c))}), nil
+	case "<=":
+		return numericOnlyDomain(versionInterval{upper: inclusiveBound(c.check)}), nil
+	case "^":
+		return caretConstraintDomain(c), nil
+	case "~":
+		return tildeConstraintDomain(c), nil
+	default:
+		return constraintDomain{}, nil
+	}
+}
+
+func allConstraintDomain() constraintDomain {
+	return constraintDomain{
+		numeric:       []versionInterval{{}},
+		anyBranch:     true,
+		branches:      map[string]struct{}{},
+		branchExclude: map[string]struct{}{},
+	}
+}
+
+func numericOnlyDomain(interval versionInterval) constraintDomain {
+	return constraintDomain{
+		numeric:       []versionInterval{interval},
+		branches:      map[string]struct{}{},
+		branchExclude: map[string]struct{}{},
+	}
+}
+
+func branchOnlyDomain(branch string) constraintDomain {
+	return constraintDomain{
+		branches:      map[string]struct{}{branch: {}},
+		branchExclude: map[string]struct{}{},
+	}
+}
+
+func isConstraintWildcard(c *Constraint) bool {
+	if c.check == nil {
+		return true
+	}
+	_, version, _, ok := splitConstraintParts(c.original)
+	return ok && c.origSegments > 1 && isWildcardConstraintVersion(version) && !isNumericDevBranch(version)
+}
+
+func wildcardConstraintDomain(c *Constraint) constraintDomain {
+	fixedLen := c.origSegments - 1
+	if fixedLen <= 0 || c.check == nil {
+		return allConstraintDomain()
+	}
+
+	lower := implicitDevVersion(prefixStart(c.check, fixedLen))
+	upper := implicitDevVersion(prefixEnd(c.check, fixedLen))
+
+	switch c.operator {
+	case ">=":
+		return numericOnlyDomain(versionInterval{lower: inclusiveBound(lower)})
+	case ">":
+		return numericOnlyDomain(versionInterval{lower: inclusiveBound(upper)})
+	case "<=":
+		return numericOnlyDomain(versionInterval{upper: exclusiveBound(upper)})
+	case "<":
+		return numericOnlyDomain(versionInterval{upper: exclusiveBound(lower)})
+	case "!=", "<>":
+		return allConstraintDomain()
+	default:
+		return numericOnlyDomain(versionInterval{
+			lower: inclusiveBound(lower),
+			upper: exclusiveBound(upper),
+		})
+	}
+}
+
+func caretConstraintDomain(c *Constraint) constraintDomain {
+	return numericOnlyDomain(versionInterval{
+		lower: inclusiveBound(implicitDevLowerBound(c)),
+		upper: exclusiveBound(implicitDevVersion(caretUpperBound(c))),
+	})
+}
+
+func caretUpperBound(c *Constraint) *Version {
+	segments := c.check.Segments64()
+	if segments[0] == 0 && isMajorZeroNumericDevBranchWildcard(c) {
+		return numericVersion(1, 0, 0)
+	}
+	switch {
+	case segments[0] != 0:
+		return numericVersion(segments[0]+1, 0, 0)
+	case c.origSegments <= 1:
+		return numericVersion(1, 0, 0)
+	case segments[1] != 0 || c.origSegments <= 2:
+		return numericVersion(0, segments[1]+1, 0)
+	default:
+		return numericVersion(0, 0, segments[2]+1)
+	}
+}
+
+func isMajorZeroNumericDevBranchWildcard(c *Constraint) bool {
+	_, version, _, ok := splitConstraintParts(c.original)
+	if !ok || !isNumericDevBranch(version) {
+		return false
+	}
+	version = strings.TrimSpace(version)
+	if len(version) > 1 && (version[0] == 'v' || version[0] == 'V') {
+		version = version[1:]
+	}
+	version = strings.TrimSuffix(version, version[len(version)-4:])
+	parts := strings.Split(version, ".")
+	return len(parts) == 2 && parts[0] == "0" && isWildcardSegment(parts[1])
+}
+
+func tildeConstraintDomain(c *Constraint) constraintDomain {
+	segments := c.check.Segments64()
+	upper := numericVersion(segments[0]+1, 0, 0)
+	if c.origSegments >= 4 {
+		upper = numericVersion(segments[0], segments[1], segments[2]+1)
+	} else if c.origSegments >= 3 {
+		upper = numericVersion(segments[0], segments[1]+1, 0)
+	}
+
+	return numericOnlyDomain(versionInterval{
+		lower: inclusiveBound(implicitDevLowerBound(c)),
+		upper: exclusiveBound(implicitDevVersion(upper)),
+	})
+}
+
+func implicitDevLowerBound(c *Constraint) *Version {
+	if c.stableBound || c.check.IsPrerelease() {
+		return c.check
+	}
+	return implicitDevVersion(c.check)
+}
+
+func implicitDevUpperBound(c *Constraint) *Version {
+	if c.stableBound || c.check.IsPrerelease() {
+		return c.check
+	}
+	return implicitDevVersion(c.check)
+}
+
+func implicitDevVersion(v *Version) *Version {
+	if v.IsPrerelease() || v.branch != "" {
+		return v
+	}
+	return &Version{
+		segments: v.Segments64(),
+		si:       v.si,
+		original: v.original,
+		pre:      "dev",
+	}
+}
+
+func prefixStart(v *Version, fixedLen int) *Version {
+	segments := v.Segments64()
+	result := append([]int64{}, segments[:fixedLen]...)
+	for len(result) < 3 {
+		result = append(result, 0)
+	}
+	return numericVersion(result...)
+}
+
+func prefixEnd(v *Version, fixedLen int) *Version {
+	segments := append([]int64{}, v.Segments64()...)
+	for len(segments) < fixedLen {
+		segments = append(segments, 0)
+	}
+	result := append([]int64{}, segments[:fixedLen]...)
+	result[len(result)-1]++
+	for len(result) < 3 {
+		result = append(result, 0)
+	}
+	return numericVersion(result...)
+}
+
+func numericVersion(segments ...int64) *Version {
+	copied := append([]int64{}, segments...)
+	for len(copied) < 4 {
+		copied = append(copied, 0)
+	}
+	parts := make([]string, len(copied))
+	for i, segment := range copied {
+		parts[i] = strconv.FormatInt(segment, 10)
+	}
+	return &Version{segments: copied, si: len(copied), original: joinVersionParts(parts)}
+}
+
+func joinVersionParts(parts []string) string {
+	result := ""
+	for i, part := range parts {
+		if i > 0 {
+			result += "."
+		}
+		result += part
+	}
+	return result
+}
+
+func intersectDomains(left, right constraintDomain) constraintDomain {
+	result := constraintDomain{
+		branches:      map[string]struct{}{},
+		branchExclude: mergeBranchExclusions(left.branchExclude, right.branchExclude),
+	}
+
+	for _, leftInterval := range left.numeric {
+		for _, rightInterval := range right.numeric {
+			if interval, ok := intersectIntervals(leftInterval, rightInterval); ok {
+				result.numeric = append(result.numeric, interval)
+			}
+		}
+	}
+
+	result.anyBranch = left.anyBranch && right.anyBranch
+	for branch := range left.branches {
+		if right.anyBranch || hasBranch(right.branches, branch) {
+			addBranchIfAllowed(result.branches, branch, result.branchExclude)
+		}
+	}
+	for branch := range right.branches {
+		if left.anyBranch || hasBranch(left.branches, branch) {
+			addBranchIfAllowed(result.branches, branch, result.branchExclude)
+		}
+	}
+
+	return result
+}
+
+func mergeBranchExclusions(left, right map[string]struct{}) map[string]struct{} {
+	result := map[string]struct{}{}
+	for branch := range left {
+		result[branch] = struct{}{}
+	}
+	for branch := range right {
+		result[branch] = struct{}{}
+	}
+	return result
+}
+
+func hasBranch(branches map[string]struct{}, branch string) bool {
+	_, ok := branches[branch]
+	return ok
+}
+
+func addBranchIfAllowed(branches map[string]struct{}, branch string, excluded map[string]struct{}) {
+	if _, ok := excluded[branch]; ok {
+		return
+	}
+	branches[branch] = struct{}{}
+}
+
+func domainsIntersect(left, right constraintDomain) bool {
+	intersection := intersectDomains(left, right)
+	if len(intersection.numeric) > 0 {
+		return true
+	}
+	if len(intersection.branches) > 0 {
+		return true
+	}
+	return intersection.anyBranch
+}
+
+func domainEmpty(domain constraintDomain) bool {
+	return len(domain.numeric) == 0 && !domain.anyBranch && len(domain.branches) == 0
+}
+
+func domainSubsetOfUnion(left constraintDomain, rights []constraintDomain) bool {
+	rightIntervals := unionNumericIntervals(rights)
+	for _, leftInterval := range left.numeric {
+		if !intervalSubsetOfUnion(leftInterval, rightIntervals) {
+			return false
+		}
+	}
+
+	for branch := range left.branches {
+		if !unionAllowsBranch(rights, branch) {
+			return false
+		}
+	}
+
+	if left.anyBranch && !anyBranchSubsetOfUnion(left, rights) {
+		return false
+	}
+
+	return true
+}
+
+func domainUnionSubsetOfUnion(left, right []constraintDomain) bool {
+	for _, leftDomain := range left {
+		if domainEmpty(leftDomain) {
+			continue
+		}
+		if !domainSubsetOfUnion(leftDomain, right) {
+			return false
+		}
+	}
+	return true
+}
+
+func domainUnionsEquivalent(left, right []constraintDomain) bool {
+	return domainUnionSubsetOfUnion(left, right) && domainUnionSubsetOfUnion(right, left)
+}
+
+func domainUnionEmpty(domains []constraintDomain) bool {
+	for _, domain := range domains {
+		if !domainEmpty(domain) {
+			return false
+		}
+	}
+	return true
+}
+
+func anyBranchSubsetOfUnion(left constraintDomain, rights []constraintDomain) bool {
+	if !unionHasAnyBranch(rights) {
+		return false
+	}
+
+	for branch := range branchesExcludedByEveryAnyBranch(rights) {
+		if _, leftExcludes := left.branchExclude[branch]; !leftExcludes {
+			return false
+		}
+	}
+
+	return true
+}
+
+func unionHasAnyBranch(domains []constraintDomain) bool {
+	for _, domain := range domains {
+		if domain.anyBranch {
+			return true
+		}
+	}
+	return false
+}
+
+func branchesExcludedByEveryAnyBranch(domains []constraintDomain) map[string]struct{} {
+	var excluded map[string]struct{}
+	for _, domain := range domains {
+		if !domain.anyBranch {
+			continue
+		}
+		if excluded == nil {
+			excluded = copyStringSet(domain.branchExclude)
+			continue
+		}
+		for branch := range excluded {
+			if _, ok := domain.branchExclude[branch]; !ok {
+				delete(excluded, branch)
+			}
+		}
+	}
+	if excluded == nil {
+		return map[string]struct{}{}
+	}
+	for _, domain := range domains {
+		for branch := range domain.branches {
+			delete(excluded, branch)
+		}
+	}
+	return excluded
+}
+
+func copyStringSet(input map[string]struct{}) map[string]struct{} {
+	result := map[string]struct{}{}
+	for value := range input {
+		result[value] = struct{}{}
+	}
+	return result
+}
+
+func unionAllowsBranch(domains []constraintDomain, branch string) bool {
+	for _, domain := range domains {
+		if domain.anyBranch {
+			if _, excluded := domain.branchExclude[branch]; !excluded {
+				return true
+			}
+		}
+		if _, ok := domain.branches[branch]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,239 @@
+package version
+
+import (
+	"strings"
+	"testing"
+)
+
+// These fuzz targets exercise the untrusted-input entry points of the library
+// (version strings and constraint strings). The properties they assert are
+// deliberately simple and robust:
+//
+//   - parsing arbitrary input must never panic, only return an error;
+//   - normalization is idempotent and its output re-parses;
+//   - comparison is reflexive and antisymmetric;
+//   - Satisfies agrees with NewConstraint(...).Check(...).
+//
+// Run a single target with, e.g.:
+//
+//	go test -run=Fuzz -fuzz=FuzzNewVersion -fuzztime=30s
+//
+// The static seed corpus below keeps these useful as fast regression tests
+// under plain `go test` even when fuzzing is not engaged.
+
+// versionSeeds covers well-formed, degenerate, and adversarial version inputs.
+var versionSeeds = []string{
+	"",
+	" ",
+	"0",
+	"1",
+	"1.2",
+	"1.2.3",
+	"1.2.3.4",
+	"v1.2.3",
+	"V1.2.3",
+	"1.0.0-alpha",
+	"1.0.0-alpha.1",
+	"1.0.0-beta2",
+	"1.0.0-rc.1",
+	"1.0.0-RC1",
+	"1.0.0-patch1",
+	"1.0.0-p1",
+	"1.0.0-pl3-dev",
+	"1.0.0+build.123",
+	"1.0.0-beta.5+foo",
+	"dev-main",
+	"dev-feature/x",
+	"2.1.x-dev",
+	"20100102-203040",
+	"201903.0-p2",
+	"1.0.0.0.0",
+	"9999999999999999999999999.0.0",
+	"99999.99999.99999",
+	"1.",
+	".1",
+	"1..2",
+	"-",
+	"+",
+	"@",
+	"~",
+	"^",
+	"1.0.0-",
+	"1.0.0+",
+	"1.0.0@",
+	"\x00",
+	"1.0.0\n",
+	"  1.2.3  ",
+}
+
+// constraintSeeds covers operators, ranges, wildcards, unions, and junk.
+var constraintSeeds = []string{
+	"",
+	"*",
+	"1.2.3",
+	"=1.2.3",
+	"==1.2.3",
+	"!=1.2.3",
+	">1.0",
+	">=1.0",
+	"<2.0",
+	"<=2.0",
+	"^1.0",
+	"^0.2.0",
+	"~1.2",
+	"~1.2.3",
+	"1.2.*",
+	"2.*",
+	">=1.0,<2.0",
+	">=1.0 <2.0",
+	"1.0 - 2.0",
+	"^1.0 || ^2.0",
+	">=1.0@stable",
+	">=1.0@beta",
+	"dev-main",
+	"!= dev-foo",
+	">>1.0",
+	"^.*",
+	"~x.y",
+	"||",
+	",",
+	" - ",
+	"1 - ",
+	" - 2",
+	"@stable",
+	">=1.0.0@foo",
+}
+
+func FuzzNewVersion(f *testing.F) {
+	for _, s := range versionSeeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		v, err := NewVersion(s)
+		if err != nil {
+			// A parse error is a valid, expected outcome for junk input.
+			return
+		}
+		if v == nil {
+			t.Fatalf("NewVersion(%q) returned nil version and nil error", s)
+		}
+
+		// A parsed version must compare equal to itself.
+		if cmp := v.Compare(v); cmp != 0 {
+			t.Fatalf("NewVersion(%q).Compare(self) = %d, want 0", s, cmp)
+		}
+
+		// The normalized form must re-parse, and re-parsing it must be stable.
+		norm := v.NormalizedString()
+		v2, err := NewVersion(norm)
+		if err != nil {
+			t.Fatalf("re-parsing NormalizedString()=%q of %q failed: %v", norm, s, err)
+		}
+		if cmp := v.Compare(v2); cmp != 0 {
+			t.Fatalf("NewVersion(%q) != NewVersion(NormalizedString()=%q): Compare=%d", s, norm, cmp)
+		}
+		if norm2 := v2.NormalizedString(); norm2 != norm {
+			t.Fatalf("NormalizedString not idempotent for %q: %q vs %q", s, norm, norm2)
+		}
+	})
+}
+
+func FuzzNormalizeComposerVersion(f *testing.F) {
+	for _, s := range versionSeeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		norm, err := NormalizeComposerVersion(s)
+		if err != nil {
+			return
+		}
+
+		// The normalizer mirrors Composer at the string level. Two Composer
+		// quirks mean we cannot assert stronger properties here:
+		//   - it is NOT strictly idempotent for some date-style inputs
+		//     ("0000-00" -> "0000.00" -> "0000.00.0.0"); and
+		//   - it can emit a numeric segment wider than int64
+		//     ("9227000000000000000"), which NewVersion later rejects.
+		// The genuine safety property is simply that feeding the output back in
+		// never panics. (Re-normalization may legitimately return an error.)
+		_, _ = NormalizeComposerVersion(norm)
+	})
+}
+
+func FuzzNewConstraint(f *testing.F) {
+	for _, s := range constraintSeeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		c, err := NewConstraint(s)
+		if err != nil {
+			return
+		}
+
+		// A parsed constraint must be checkable against any valid version
+		// without panicking.
+		for _, vs := range []string{"1.0.0", "0.0.1", "2.5.3", "1.0.0-beta", "dev-main"} {
+			v, verr := NewVersion(vs)
+			if verr != nil {
+				continue
+			}
+			_ = c.Check(v)
+		}
+	})
+}
+
+func FuzzSatisfies(f *testing.F) {
+	// Seed with the cross product of a few versions and constraints.
+	for _, vs := range []string{"1.2.3", "1.0.0-beta", "2.0.0", "dev-main"} {
+		for _, cs := range []string{"^1.0", ">=1.0,<2.0", "*", "~1.2", "1.0 - 2.0"} {
+			f.Add(vs, cs)
+		}
+	}
+
+	f.Fuzz(func(t *testing.T, versionString, constraintString string) {
+		got, err := Satisfies(versionString, constraintString)
+		if err != nil {
+			return
+		}
+
+		// Satisfies must agree with the lower-level NewConstraint/Check path.
+		// Mirror Satisfies' own special-casing of empty/"*" constraints.
+		v, verr := NewVersion(versionString)
+		if verr != nil {
+			t.Fatalf("Satisfies(%q, %q) succeeded but NewVersion failed: %v", versionString, constraintString, verr)
+		}
+
+		want := got
+		if trimmed := strings.TrimSpace(constraintString); trimmed != "" && trimmed != "*" {
+			c, cerr := NewConstraint(trimmed)
+			if cerr != nil {
+				t.Fatalf("Satisfies(%q, %q) succeeded but NewConstraint failed: %v", versionString, constraintString, cerr)
+			}
+			want = c.Check(v)
+		} else {
+			want = true
+		}
+
+		if got != want {
+			t.Fatalf("Satisfies(%q, %q)=%v disagrees with NewConstraint().Check()=%v", versionString, constraintString, got, want)
+		}
+	})
+}
+
+func FuzzConstraintIntersects(f *testing.F) {
+	for _, a := range constraintSeeds {
+		for _, b := range []string{"^1.0", ">=1.0,<2.0", "1.2.*", "dev-main"} {
+			f.Add(a, b)
+		}
+	}
+
+	f.Fuzz(func(t *testing.T, left, right string) {
+		// Both ConstraintIntersects and ConstraintSubsetOf must never panic on
+		// arbitrary input; errors are an acceptable outcome.
+		_, _ = ConstraintIntersects(left, right)
+		_, _ = ConstraintSubsetOf(left, right)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/shyim/go-version
+
+go 1.23

--- a/intersect.go
+++ b/intersect.go
@@ -1,0 +1,125 @@
+package version
+
+import (
+	"strings"
+)
+
+// ConstraintIntersects reports whether two Composer constraints can match at
+// least one common version.
+func ConstraintIntersects(left, right string) (bool, error) {
+	left = normalizeConstraintInput(left)
+	right = normalizeConstraintInput(right)
+
+	leftDomains, err := constraintUnionDomains(left)
+	if err != nil {
+		return false, err
+	}
+	rightDomains, err := constraintUnionDomains(right)
+	if err != nil {
+		return false, err
+	}
+
+	for _, leftDomain := range leftDomains {
+		for _, rightDomain := range rightDomains {
+			if domainsIntersect(leftDomain, rightDomain) {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// ConstraintSubsetOf reports whether every version matched by left is also
+// matched by right.
+
+// ConstraintSubsetOf reports whether every version matched by left is also
+// matched by right.
+func ConstraintSubsetOf(left, right string) (bool, error) {
+	leftDomains, err := constraintUnionDomains(normalizeConstraintInput(left))
+	if err != nil {
+		return false, err
+	}
+	rightDomains, err := constraintUnionDomains(normalizeConstraintInput(right))
+	if err != nil {
+		return false, err
+	}
+
+	for _, leftDomain := range leftDomains {
+		if domainEmpty(leftDomain) {
+			continue
+		}
+		if !domainSubsetOfUnion(leftDomain, rightDomains) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func normalizeConstraintInput(constraint string) string {
+	constraint = strings.TrimSpace(constraint)
+	if constraint == "" {
+		return "*"
+	}
+	return constraint
+}
+
+func constraintUnionDomains(constraint string) ([]constraintDomain, error) {
+	parsed, err := NewConstraint(constraint)
+	if err != nil {
+		return nil, err
+	}
+
+	domains := make([]constraintDomain, 0, len(parsed))
+	for _, andConstraints := range parsed {
+		domain, err := constraintsDomain(andConstraints)
+		if err != nil {
+			return nil, err
+		}
+		domains = append(domains, domain)
+	}
+	return domains, nil
+}
+
+func composeConstraintDomains(parts []string, conjunctive bool) ([]constraintDomain, error) {
+	if len(parts) == 0 {
+		return []constraintDomain{allConstraintDomain()}, nil
+	}
+
+	if !conjunctive {
+		var domains []constraintDomain
+		for _, part := range parts {
+			partDomains, err := constraintUnionDomains(normalizeConstraintInput(part))
+			if err != nil {
+				return nil, err
+			}
+			domains = append(domains, partDomains...)
+		}
+		return domains, nil
+	}
+
+	domains := []constraintDomain{allConstraintDomain()}
+	for _, part := range parts {
+		partDomains, err := constraintUnionDomains(normalizeConstraintInput(part))
+		if err != nil {
+			return nil, err
+		}
+
+		var next []constraintDomain
+		for _, left := range domains {
+			for _, right := range partDomains {
+				intersection := intersectDomains(left, right)
+				if !domainEmpty(intersection) {
+					next = append(next, intersection)
+				}
+			}
+		}
+		domains = next
+		if len(domains) == 0 {
+			break
+		}
+	}
+
+	return domains, nil
+}

--- a/intersect_test.go
+++ b/intersect_test.go
@@ -1,0 +1,213 @@
+package version
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestConstraintIntersects(t *testing.T) {
+	tests := []struct {
+		left     string
+		right    string
+		expected bool
+	}{
+		{"^6.4", ">=6.4.0,<6.4.29", true},
+		{"^6.4", ">=7.0.0,<7.1.0", false},
+		{"^1.0", "^1.0", true},
+		{"^1.0", "^2.0", false},
+		{"^0.2.0", ">=0.2.1,<0.3.0", true},
+		{"^0.2.0", ">=0.3.0", false},
+		{"1.0 - 2.0", "2.0.*", true},
+		{"1.0 - 2.0", "2.1.*", false},
+		{"1.2.*", ">=1.2.5,<1.3.0", true},
+		{"1.2.*", ">=1.3.0", false},
+		{">1.0", "<2.0", true},
+		{">=1.0,<2.0", ">=2.0", false},
+		{"1.2.3", ">=1.0,<2.0", true},
+		{"1.2.3", ">=2.0", false},
+		{"dev-main", "dev-main", true},
+		{"dev-main", "dev-feature", false},
+		{"*", "dev-main", true},
+		{"*", "^1.0", true},
+		{"", "^1.0", true},
+		{"!=1.2.3", "1.2.3", false},
+		{"!=1.2.3", "1.2.4", true},
+	}
+
+	for _, tc := range tests {
+		actual, err := ConstraintIntersects(tc.left, tc.right)
+		if err != nil {
+			t.Errorf("ConstraintIntersects(%q, %q) unexpected error: %v", tc.left, tc.right, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("ConstraintIntersects(%q, %q): expected %v, got %v", tc.left, tc.right, tc.expected, actual)
+		}
+	}
+}
+
+// TestConstraintIntersectsStability locks in Composer's behavior around
+// @stability flags. Composer strips the @stability flag from a constraint and
+// discards it entirely when it is "stable", so ">=1.0@stable" behaves exactly
+// like ">=1.0". An explicit "-stable" version modifier is a different thing and
+// is preserved, which raises the lower bound above same-version prereleases.
+func TestConstraintIntersectsStability(t *testing.T) {
+	tests := []struct {
+		left     string
+		right    string
+		expected bool
+	}{
+		// @stable flag is ignored: identical to plain ">=1.0".
+		{">=1.0@stable", "1.0-beta", true},
+		{">=1.0", "1.0-beta", true},
+		// Explicit -stable modifier is kept: excludes the same-version prerelease.
+		{">=1.0-stable", "1.0-beta", false},
+		// Other flags and ranges keep matching Composer.
+		{">=1.0@stable", "1.1-beta", true},
+		{">=1.0@stable", "2.0.0", true},
+		{"^1.0@beta", "1.0-beta", true},
+		{"<2.0@stable", "1.0-beta", true},
+	}
+
+	for _, tc := range tests {
+		actual, err := ConstraintIntersects(tc.left, tc.right)
+		if err != nil {
+			t.Errorf("ConstraintIntersects(%q, %q) unexpected error: %v", tc.left, tc.right, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("ConstraintIntersects(%q, %q): expected %v, got %v", tc.left, tc.right, tc.expected, actual)
+		}
+	}
+}
+
+func TestConstraintSubsetOfStability(t *testing.T) {
+	tests := []struct {
+		left     string
+		right    string
+		expected bool
+	}{
+		// ">=1.0@stable" == ">=1.0", so each is a subset of the other.
+		{">=1.0@stable", ">=1.0", true},
+		{">=1.0", ">=1.0@stable", true},
+		// ">=1.0-stable" excludes 1.0 prereleases, so it is a strict subset of
+		// ">=1.0" but ">=1.0" is not a subset of it.
+		{">=1.0-stable", ">=1.0", true},
+		{">=1.0", ">=1.0-stable", false},
+	}
+
+	for _, tc := range tests {
+		actual, err := ConstraintSubsetOf(tc.left, tc.right)
+		if err != nil {
+			t.Errorf("ConstraintSubsetOf(%q, %q) unexpected error: %v", tc.left, tc.right, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("ConstraintSubsetOf(%q, %q): expected %v, got %v", tc.left, tc.right, tc.expected, actual)
+		}
+	}
+}
+
+func TestConstraintIntersectsErrors(t *testing.T) {
+	if _, err := ConstraintIntersects("^1.0", ">>1.0"); err == nil {
+		t.Fatal("expected malformed constraint error")
+	}
+}
+
+func TestConstraintSubsetOf(t *testing.T) {
+	tests := []struct {
+		left     string
+		right    string
+		expected bool
+	}{
+		{"^1.2", "^1.0 || ^2.0", true},
+		{"^1.0 || ^2.0", "^1.0", false},
+		{"*", ">=1 || <1", false},
+		{"!= dev-foo", "!= dev-foo", true},
+		{"!= dev-foo", "!= dev-bar", false},
+		{"< dev-foo", "= dev-foo", true},
+		{"^1.1, !=1.5.0", ">1.0.0", true},
+		{">1.6", ">1.5, >1.4, !=1.7", false},
+	}
+
+	for _, tc := range tests {
+		actual, err := ConstraintSubsetOf(tc.left, tc.right)
+		if err != nil {
+			t.Errorf("ConstraintSubsetOf(%q, %q) unexpected error: %v", tc.left, tc.right, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("ConstraintSubsetOf(%q, %q): expected %v, got %v", tc.left, tc.right, tc.expected, actual)
+		}
+	}
+}
+
+func TestComposeConstraintDomains(t *testing.T) {
+	tests := []struct {
+		name        string
+		parts       []string
+		conjunctive bool
+		expected    string
+		empty       bool
+	}{
+		{
+			name:        "disjunctive union",
+			parts:       []string{"1.0", "2.0"},
+			conjunctive: false,
+			expected:    "1.0 || 2.0",
+		},
+		{
+			name:        "conjunctive intersection",
+			parts:       []string{"^1.0", "^1.2"},
+			conjunctive: true,
+			expected:    "^1.2",
+		},
+		{
+			name:        "conjunctive conflict",
+			parts:       []string{"1.0", "2.0"},
+			conjunctive: true,
+			empty:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		actual, err := composeConstraintDomains(tc.parts, tc.conjunctive)
+		if err != nil {
+			t.Errorf("%s: composeConstraintDomains unexpected error: %v", tc.name, err)
+			continue
+		}
+		if tc.empty {
+			if !domainUnionEmpty(actual) {
+				t.Errorf("%s: expected empty composed domain", tc.name)
+			}
+			continue
+		}
+		expected, err := constraintUnionDomains(tc.expected)
+		if err != nil {
+			t.Errorf("%s: constraintUnionDomains unexpected error: %v", tc.name, err)
+			continue
+		}
+		if !domainUnionsEquivalent(actual, expected) {
+			t.Errorf("%s: expected composed domain equivalent to %q", tc.name, tc.expected)
+		}
+	}
+}
+
+func TestDomainUnionSnapshot(t *testing.T) {
+	domains, err := constraintUnionDomains("!= 6, > 5")
+	if err != nil {
+		t.Fatalf("constraintUnionDomains unexpected error: %v", err)
+	}
+
+	actual := domainUnionSnapshot(domains)
+	expected := domainSnapshot{
+		Numeric: []intervalSnapshot{
+			{Start: "> 5.0.0.0", End: "< 6.0.0.0"},
+			{Start: "> 6.0.0.0", End: "< +Inf"},
+		},
+		Branches: branchSnapshot{Names: []string{}},
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("expected %#v, got %#v", expected, actual)
+	}
+}

--- a/interval.go
+++ b/interval.go
@@ -1,0 +1,292 @@
+package version
+
+import "sort"
+
+// This file holds the numeric version-interval primitives: half-open ranges
+// with inclusive/exclusive bounds, and the lower/upper bound arithmetic used to
+// intersect and cover intervals.
+
+type versionInterval struct {
+	lower      *versionBound
+	upper      *versionBound
+	exclusions []*Version
+}
+
+type versionBound struct {
+	version   *Version
+	inclusive bool
+}
+
+func minLowerBound(left, right *versionBound) *versionBound {
+	if left == nil || right == nil {
+		return nil
+	}
+	cmp := left.version.Compare(right.version)
+	if cmp < 0 {
+		return left
+	}
+	if cmp > 0 {
+		return right
+	}
+	return &versionBound{version: left.version, inclusive: left.inclusive || right.inclusive}
+}
+
+func inclusiveBound(v *Version) *versionBound {
+	return &versionBound{version: v, inclusive: true}
+}
+
+func exclusiveBound(v *Version) *versionBound {
+	return &versionBound{version: v}
+}
+
+func intersectIntervals(left, right versionInterval) (versionInterval, bool) {
+	interval := versionInterval{
+		lower:      maxLower(left.lower, right.lower),
+		upper:      minUpper(left.upper, right.upper),
+		exclusions: append(append([]*Version{}, left.exclusions...), right.exclusions...),
+	}
+	if !intervalHasAnyVersion(interval) {
+		return versionInterval{}, false
+	}
+	return interval, true
+}
+
+func maxLower(left, right *versionBound) *versionBound {
+	if left == nil {
+		return right
+	}
+	if right == nil {
+		return left
+	}
+	cmp := left.version.Compare(right.version)
+	if cmp > 0 {
+		return left
+	}
+	if cmp < 0 {
+		return right
+	}
+	return &versionBound{version: left.version, inclusive: left.inclusive && right.inclusive}
+}
+
+func minUpper(left, right *versionBound) *versionBound {
+	if left == nil {
+		return right
+	}
+	if right == nil {
+		return left
+	}
+	cmp := left.version.Compare(right.version)
+	if cmp < 0 {
+		return left
+	}
+	if cmp > 0 {
+		return right
+	}
+	return &versionBound{version: left.version, inclusive: left.inclusive && right.inclusive}
+}
+
+func maxUpper(left, right *versionBound) *versionBound {
+	if left == nil || right == nil {
+		return nil
+	}
+	cmp := left.version.Compare(right.version)
+	if cmp > 0 {
+		return left
+	}
+	if cmp < 0 {
+		return right
+	}
+	return &versionBound{version: left.version, inclusive: left.inclusive || right.inclusive}
+}
+
+func intervalHasAnyVersion(interval versionInterval) bool {
+	if interval.lower != nil && interval.upper != nil {
+		cmp := interval.lower.version.Compare(interval.upper.version)
+		if cmp > 0 {
+			return false
+		}
+		if cmp == 0 {
+			if !interval.lower.inclusive || !interval.upper.inclusive {
+				return false
+			}
+			return !versionExcluded(interval.lower.version, interval.exclusions)
+		}
+	}
+	return true
+}
+
+func versionExcluded(v *Version, exclusions []*Version) bool {
+	for _, excluded := range exclusions {
+		if v.Equal(excluded) {
+			return true
+		}
+	}
+	return false
+}
+
+func intervalsCanMerge(left, right versionInterval) bool {
+	if left.upper == nil || right.lower == nil {
+		return true
+	}
+	cmp := left.upper.version.Compare(right.lower.version)
+	if cmp > 0 {
+		return true
+	}
+	if cmp < 0 {
+		return false
+	}
+	return left.upper.inclusive || right.lower.inclusive
+}
+
+func unionNumericIntervals(domains []constraintDomain) []versionInterval {
+	var intervals []versionInterval
+	for _, domain := range domains {
+		intervals = append(intervals, domain.numeric...)
+	}
+	return intervals
+}
+
+func intervalSubsetOfUnion(left versionInterval, rights []versionInterval) bool {
+	if !intervalCoveredByUnion(left, rights) {
+		return false
+	}
+
+	for _, excluded := range unionNumericExclusions(rights) {
+		if !versionInInterval(excluded, left, false) {
+			continue
+		}
+		if versionExcluded(excluded, left.exclusions) {
+			continue
+		}
+		if !unionAllowsNumericVersion(rights, excluded) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func intervalCoveredByUnion(left versionInterval, rights []versionInterval) bool {
+	if len(rights) == 0 {
+		return false
+	}
+
+	sorted := append([]versionInterval{}, rights...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return lowerBefore(sorted[i].lower, sorted[j].lower)
+	})
+
+	cursor := left.lower
+	for _, right := range sorted {
+		if upperBeforeCursor(right.upper, cursor) {
+			continue
+		}
+		if !lowerCoversCursor(right.lower, cursor) {
+			return false
+		}
+		if upperReaches(right.upper, left.upper) {
+			return true
+		}
+		if right.upper == nil {
+			return true
+		}
+		cursor = &versionBound{version: right.upper.version, inclusive: !right.upper.inclusive}
+	}
+
+	return false
+}
+
+func lowerBefore(left, right *versionBound) bool {
+	if left == nil {
+		return right != nil
+	}
+	if right == nil {
+		return false
+	}
+	cmp := left.version.Compare(right.version)
+	if cmp != 0 {
+		return cmp < 0
+	}
+	if left.inclusive == right.inclusive {
+		return false
+	}
+	return left.inclusive
+}
+
+func upperBeforeCursor(upper, cursor *versionBound) bool {
+	if upper == nil || cursor == nil {
+		return false
+	}
+	cmp := upper.version.Compare(cursor.version)
+	if cmp != 0 {
+		return cmp < 0
+	}
+	return !upper.inclusive || !cursor.inclusive
+}
+
+func lowerCoversCursor(lower, cursor *versionBound) bool {
+	if lower == nil {
+		return true
+	}
+	if cursor == nil {
+		return false
+	}
+	cmp := lower.version.Compare(cursor.version)
+	if cmp != 0 {
+		return cmp < 0
+	}
+	if cursor.inclusive && !lower.inclusive {
+		return false
+	}
+	return true
+}
+
+func upperReaches(upper, target *versionBound) bool {
+	if target == nil {
+		return upper == nil
+	}
+	if upper == nil {
+		return true
+	}
+	cmp := upper.version.Compare(target.version)
+	if cmp != 0 {
+		return cmp > 0
+	}
+	if target.inclusive && !upper.inclusive {
+		return false
+	}
+	return true
+}
+
+func unionNumericExclusions(intervals []versionInterval) []*Version {
+	var exclusions []*Version
+	for _, interval := range intervals {
+		exclusions = append(exclusions, interval.exclusions...)
+	}
+	return exclusions
+}
+
+func unionAllowsNumericVersion(intervals []versionInterval, version *Version) bool {
+	for _, interval := range intervals {
+		if versionInInterval(version, interval, true) {
+			return true
+		}
+	}
+	return false
+}
+
+func versionInInterval(version *Version, interval versionInterval, respectExclusions bool) bool {
+	if interval.lower != nil {
+		cmp := version.Compare(interval.lower.version)
+		if cmp < 0 || (cmp == 0 && !interval.lower.inclusive) {
+			return false
+		}
+	}
+	if interval.upper != nil {
+		cmp := version.Compare(interval.upper.version)
+		if cmp > 0 || (cmp == 0 && !interval.upper.inclusive) {
+			return false
+		}
+	}
+	return !respectExclusions || !versionExcluded(version, interval.exclusions)
+}

--- a/normalize_fastpath_test.go
+++ b/normalize_fastpath_test.go
@@ -1,0 +1,107 @@
+package version
+
+import (
+	"strconv"
+	"testing"
+)
+
+// regexpOnlyNormalize reproduces the classical-versioning branch of the full
+// normalizer without the fast path, serving as the behavioral oracle for
+// fastNumericNormalize. It mirrors normalizer.go's reClassical handling: 1-4
+// digit segments (first <=5 digits), padded to four with ".0", leading zeros
+// preserved verbatim.
+func regexpOnlyNormalize(t *testing.T, version string) (string, bool) {
+	t.Helper()
+	matches := reClassical.FindStringSubmatch(version)
+	if matches == nil {
+		return "", false
+	}
+	// Reject if a stability modifier was captured; the fast path only covers
+	// pure numeric versions.
+	if matches[5] != "" || matches[6] != "" || matches[7] != "" {
+		return "", false
+	}
+	major := matches[1]
+	minor, patch, build := ".0", ".0", ".0"
+	if matches[2] != "" {
+		minor = matches[2]
+	}
+	if matches[3] != "" {
+		patch = matches[3]
+	}
+	if matches[4] != "" {
+		build = matches[4]
+	}
+	return major + minor + patch + build, true
+}
+
+// TestNormalizeFastPathParity is the safety net for the numeric fast path: for
+// every generated input, whenever fastNumericNormalize fires it must produce the
+// exact same string as the classical regexp path, and the full normalizeVersion
+// result must match too. It also checks explicit edge cases.
+func TestNormalizeFastPathParity(t *testing.T) {
+	var inputs []string
+	// Explicit edge cases called out in the analysis.
+	inputs = append(inputs,
+		"1", "1.2", "1.2.3", "1.2.3.4",
+		"v1", "v1.2", "V2.0.0",
+		"01", "01.02", "01.02.03", "00.00", "000000",
+		"99999", "99999.1", "100000", "100000.0.0", // 6-digit first segment must fall through
+		"1.2.3.4.5", // 5 segments: must fall through (to an error)
+		"1..2", "1.", ".1", "", "v",
+		"1.2.3-beta", "1.2.3@stable", "1.2.3+build", "dev-main", // non-numeric: must fall through
+	)
+	// Generated numeric combinations.
+	for a := 0; a < 12; a++ {
+		for b := 0; b < 6; b++ {
+			inputs = append(inputs,
+				strconv.Itoa(a),
+				strconv.Itoa(a)+"."+strconv.Itoa(b),
+				strconv.Itoa(a)+"."+strconv.Itoa(b)+".0",
+				"v"+strconv.Itoa(a)+"."+strconv.Itoa(b),
+				"0"+strconv.Itoa(a)+"."+strconv.Itoa(b), // leading zero
+			)
+		}
+	}
+
+	for _, in := range inputs {
+		fast, fastOK := fastNumericNormalize(trimmed(in))
+
+		// 1) When the fast path fires, it must equal the regexp classical path.
+		if fastOK {
+			ref, refOK := regexpOnlyNormalize(t, trimmed(in))
+			if !refOK {
+				t.Errorf("fast path fired for %q -> %q but regexp classical path rejected it", in, fast)
+				continue
+			}
+			if fast != ref {
+				t.Errorf("fast path %q -> %q, regexp path -> %q", in, fast, ref)
+			}
+		}
+
+		// 2) The full normalizeVersion result must be consistent regardless of
+		//    which path produced it: if the fast path fired, the public result
+		//    must equal the fast output.
+		got, err := normalizeVersion(in)
+		if fastOK {
+			if err != nil {
+				t.Errorf("normalizeVersion(%q) errored %v but fast path produced %q", in, err, fast)
+			} else if got != fast {
+				t.Errorf("normalizeVersion(%q) = %q, fast path = %q", in, got, fast)
+			}
+		}
+	}
+}
+
+func trimmed(s string) string {
+	// normalizeVersionWithContext trims before calling the fast path, so the
+	// test must too.
+	start, end := 0, len(s)
+	for start < end && (s[start] == ' ' || s[start] == '\t') {
+		start++
+	}
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\t') {
+		end--
+	}
+	return s[start:end]
+}

--- a/normalizer.go
+++ b/normalizer.go
@@ -28,12 +28,70 @@ func normalizeVersion(version string) (string, error) {
 	return normalizeVersionWithContext(version, version)
 }
 
+// fastNumericNormalize handles the common case of a plain numeric version
+// ("1.2.3", "v1.2", "01.02") without invoking the regexp pipeline. It returns
+// ok=false (falling through to the full normalizer) for anything that is not a
+// strict 1-4 segment, all-digit, <=5-digit-first-segment version. The guards
+// are deliberately conservative so the output is always identical to the
+// classical regexp path (verified by TestNormalizeFastPathParity).
+func fastNumericNormalize(version string) (string, bool) {
+	body := version
+	if len(body) > 1 && (body[0] == 'v' || body[0] == 'V') {
+		body = body[1:]
+	}
+	if body == "" {
+		return "", false
+	}
+
+	segments := make([]string, 0, 4)
+	start := 0
+	for i := 0; i <= len(body); i++ {
+		if i == len(body) || body[i] == '.' {
+			seg := body[start:i]
+			if seg == "" {
+				return "", false // empty segment, e.g. "1..2" or trailing dot
+			}
+			for j := 0; j < len(seg); j++ {
+				if seg[j] < '0' || seg[j] > '9' {
+					return "", false // non-digit: let the regexp path handle it
+				}
+			}
+			segments = append(segments, seg)
+			if len(segments) > 4 {
+				return "", false // too many segments
+			}
+			start = i + 1
+		}
+	}
+
+	// The classical regexp caps the first segment at 5 digits; longer numbers
+	// are date-style and must not be padded here.
+	if len(segments[0]) > 5 {
+		return "", false
+	}
+
+	for len(segments) < 4 {
+		segments = append(segments, "0")
+	}
+	return strings.Join(segments, "."), true
+}
+
 func normalizeVersionWithContext(version, fullVersion string) (string, error) {
 	version = strings.TrimSpace(version)
 	invalidVersion := version
 	fullVersion = strings.TrimSpace(fullVersion)
 	if fullVersion == "" {
 		fullVersion = invalidVersion
+	}
+
+	// Fast path for plain numeric versions like "1.2.3", "v1.2", "01.02".
+	// This is a strict subset of the classical regexp path below: it only fires
+	// for 1-4 all-ASCII-digit segments with a <=5-digit first segment (so
+	// 6+-digit date-style numbers still route through the date heuristic), and
+	// it copies the raw digit substrings verbatim so leading zeros are
+	// preserved exactly as the regexp path would. Anything else falls through.
+	if normalized, ok := fastNumericNormalize(version); ok {
+		return normalized, nil
 	}
 
 	// Strip off aliasing e.g. "1.2.3 as 1.2.3-alias"

--- a/normalizer.go
+++ b/normalizer.go
@@ -6,20 +6,42 @@ import (
 	"strings"
 )
 
+// Static patterns used by version normalization. Compiling a regexp is far more
+// expensive than running it, so these are built once at package load instead of
+// on every normalizeVersion call (which runs for every NewVersion).
+var (
+	reAlias     = regexp.MustCompile(`^([^,\s]+)\s+as\s+([^,\s]+)$`)
+	reStability = regexp.MustCompile(`(?i)@(?:stable|beta|dev|alpha|RC)$`)
+	reBuild     = regexp.MustCompile(`^([^,\s+]+)\+[^\s]+$`)
+
+	modifierPattern = `(?:[._-]?(stable|beta|b|alpha|a|RC|patch|p|pl|dev)([._-]?\d+(?:[._-][0-9A-Za-z-]+)*)?(?:[._-]?(dev))?)?`
+	reClassical     = regexp.MustCompile("(?i)" + fmt.Sprintf(`^v?(\d{1,5})(\.\d+)?(\.\d+)?(\.\d+)?%s$`, modifierPattern))
+	reDate          = regexp.MustCompile("(?i)" + fmt.Sprintf(`^v?(\d{4}(?:[.:-]?\d{2}){1,6}(?:[.:-]?\d{1,3}){0,2})%s$`, modifierPattern))
+	reNonDigit      = regexp.MustCompile(`\D`)
+	reDevBranch     = regexp.MustCompile(`(?i)(.*?)[.-]?dev$`)
+
+	reDevSuffixWildcard = regexp.MustCompile(`(?i)^v?\d+(?:\.(?:\d+|x|\*)){0,3}$`)
+	reNumericBranch     = regexp.MustCompile(`(?i)^v?(\d+)(\.(\d+|[xX*]))?(\.(\d+|[xX*]))?(\.(\d+|[xX*]))?$`)
+)
+
 func normalizeVersion(version string) (string, error) {
+	return normalizeVersionWithContext(version, version)
+}
+
+func normalizeVersionWithContext(version, fullVersion string) (string, error) {
 	version = strings.TrimSpace(version)
-	origVersion := version
+	invalidVersion := version
+	fullVersion = strings.TrimSpace(fullVersion)
+	if fullVersion == "" {
+		fullVersion = invalidVersion
+	}
 
 	// Strip off aliasing e.g. "1.2.3 as 1.2.3-alias"
-	aliasPattern := `^([^,\s]+)\s+as\s+([^,\s]+)$`
-	reAlias := regexp.MustCompile(aliasPattern)
 	if match := reAlias.FindStringSubmatch(version); match != nil {
 		version = match[1]
 	}
 
 	// Strip off stability flag e.g. "1.2.3@beta"
-	stabilityPattern := fmt.Sprintf("@(?:%s)$", `stable|beta|dev|alpha|RC`)
-	reStability := regexp.MustCompile("(?i)" + stabilityPattern)
 	if match := reStability.FindStringSubmatch(version); match != nil {
 		version = version[:len(version)-len(match[0])]
 	}
@@ -36,8 +58,6 @@ func normalizeVersion(version string) (string, error) {
 	}
 
 	// Strip off build metadata: e.g. "1.2.3+buildinfo"
-	buildPattern := `^([^,\s+]+)\+[^\s]+$`
-	reBuild := regexp.MustCompile(buildPattern)
 	if match := reBuild.FindStringSubmatch(version); match != nil {
 		version = match[1]
 	}
@@ -46,8 +66,6 @@ func normalizeVersion(version string) (string, error) {
 	modifierIndex := 0 // will indicate where modifiers are found in the matches
 
 	// Match classical versioning like 1.2.3.4 with optional modifiers.
-	classicalPattern := fmt.Sprintf(`^v?(\d{1,5})(\.\d+)?(\.\d+)?(\.\d+)?%s$`, `(?:-?(stable|beta|b|alpha|a|RC)(?:[.-]?(\d+))?(?:[.-]?(dev))?)?`)
-	reClassical := regexp.MustCompile("(?i)" + classicalPattern)
 	if matches = reClassical.FindStringSubmatch(version); matches != nil {
 		major := matches[1]
 		minor := ".0"
@@ -67,11 +85,9 @@ func normalizeVersion(version string) (string, error) {
 		modifierIndex = 5
 	} else {
 		// Match date(time) based versioning such as 2020.01.01 with optional modifiers.
-		datePattern := fmt.Sprintf(`^v?(\d{4}(?:[.:-]?\d{2}){1,6}(?:[.:-]?\d{1,3}){0,2})%s$`, `(?:-(stable|beta|b|alpha|a|RC)(?:[.-]?(\d+))?(?:[.-]?(dev))?)?`)
-		reDate := regexp.MustCompile("(?i)" + datePattern)
 		if matches = reDate.FindStringSubmatch(version); matches != nil {
 			// Replace any non-digit character with a dot.
-			version = regexp.MustCompile(`\D`).ReplaceAllString(matches[1], ".")
+			version = reNonDigit.ReplaceAllString(matches[1], ".")
 			// Modifier (if any) is expected at index 2.
 			modifierIndex = 2
 		}
@@ -90,7 +106,7 @@ func normalizeVersion(version string) (string, error) {
 			extra := ""
 			if len(matches) > modifierIndex+1 && matches[modifierIndex+1] != "" {
 				// Remove any leading dots or hyphens.
-				extra = strings.TrimLeft(matches[modifierIndex+1], ".-")
+				extra = strings.TrimLeft(matches[modifierIndex+1], "._-")
 			}
 			version += extra
 		}
@@ -103,38 +119,50 @@ func normalizeVersion(version string) (string, error) {
 	}
 
 	// Match dev branches such as "feature-dev" or "feature.dev"
-	devBranchPattern := `(?i)(.*?)[.-]?dev$`
-	reDevBranch := regexp.MustCompile(devBranchPattern)
 	if match := reDevBranch.FindStringSubmatch(version); match != nil {
-		normalized := normalizeBranch(match[1])
-		// A branch ending with "-dev" is only valid if it does not already contain a "dev-" prefix.
-		if !strings.Contains(normalized, "dev-") {
-			return normalized, nil
+		base := match[1]
+		// Suffix-style arbitrary branches are accepted, but Composer only
+		// applies this conversion to simple strings.
+		if canConvertDevSuffix(base) {
+			return normalizeBranch(base), nil
 		}
 	}
 
 	// If no match was found, prepare an appropriate error message.
+	// These patterns embed the (untrusted) version string, so they are compiled
+	// defensively: invalid input (e.g. non-UTF-8 bytes) only costs the richer
+	// error message rather than panicking via MustCompile.
 	extraMessage := ""
 	// Check if the alias in fullVersion must be an exact version.
-	aliasExactPattern := fmt.Sprintf(` +as +%s(?:@(?:%s))?$`, regexp.QuoteMeta(version), `stable|beta|alpha|RC`)
-	reAliasExact := regexp.MustCompile(aliasExactPattern)
-	if reAliasExact.MatchString(origVersion) {
-		extraMessage = fmt.Sprintf(` in "%s", the alias must be an exact version`, origVersion)
+	aliasExactPattern := fmt.Sprintf(` +as +%s(?:@(?:%s))?$`, regexp.QuoteMeta(version), `stable|beta|dev|alpha|RC`)
+	if reAliasExact, err := regexp.Compile(aliasExactPattern); err == nil && reAliasExact.MatchString(fullVersion) {
+		extraMessage = fmt.Sprintf(` in "%s", the alias must be an exact version`, fullVersion)
 	} else {
-		aliasSourcePattern := fmt.Sprintf(`^%s(?:@(?:%s))? +as +`, regexp.QuoteMeta(version), `stable|beta|alpha|RC`)
-		reAliasSource := regexp.MustCompile(aliasSourcePattern)
-		if reAliasSource.MatchString(origVersion) {
-			extraMessage = fmt.Sprintf(` in "%s", the alias source must be an exact version, if it is a branch name you should prefix it with dev-`, origVersion)
+		aliasSourcePattern := fmt.Sprintf(`^%s(?:@(?:%s))? +as +`, regexp.QuoteMeta(version), `stable|beta|dev|alpha|RC`)
+		if reAliasSource, err := regexp.Compile(aliasSourcePattern); err == nil && reAliasSource.MatchString(fullVersion) {
+			extraMessage = fmt.Sprintf(` in "%s", the alias source must be an exact version, if it is a branch name you should prefix it with dev-`, fullVersion)
 		}
 	}
 
-	return "", fmt.Errorf(`invalid version string "%s"%s`, origVersion, extraMessage)
+	return "", fmt.Errorf(`invalid version string "%s"%s`, invalidVersion, extraMessage)
+}
+
+func canConvertDevSuffix(base string) bool {
+	if strings.ContainsAny(base, " <>!=") || strings.Contains(strings.ToLower(base), "dev-") {
+		return false
+	}
+	if strings.Contains(base, "*") {
+		if base == "*" {
+			return false
+		}
+		return reDevSuffixWildcard.MatchString(base)
+	}
+	return true
 }
 
 func normalizeBranch(name string) string {
 	name = strings.TrimSpace(name)
-	re := regexp.MustCompile(`(?i)^v?(\d+)(\.(\d+|[xX*]))?(\.(\d+|[xX*]))?(\.(\d+|[xX*]))?$`)
-	if m := re.FindStringSubmatch(name); m != nil {
+	if m := reNumericBranch.FindStringSubmatch(name); m != nil {
 		seg1 := m[1]
 		seg2 := m[3]
 		seg3 := m[5]
@@ -158,6 +186,47 @@ func normalizeBranch(name string) string {
 	return "dev-" + name
 }
 
+func parseNumericAliasPrefix(input string) (string, bool) {
+	input = strings.TrimSpace(input)
+	if !strings.HasSuffix(strings.ToLower(input), "-dev") {
+		return "", false
+	}
+
+	base := input[:len(input)-4]
+	if len(base) > 1 && (base[0] == 'v' || base[0] == 'V') {
+		base = base[1:]
+	}
+	if base == "" {
+		return "", false
+	}
+
+	parts := strings.Split(base, ".")
+	if len(parts) > 3 {
+		return "", false
+	}
+
+	prefix := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			return "", false
+		}
+		if part == "*" || strings.EqualFold(part, "x") {
+			break
+		}
+		for _, r := range part {
+			if r < '0' || r > '9' {
+				return "", false
+			}
+		}
+		prefix = append(prefix, part)
+	}
+
+	if len(prefix) == 0 {
+		return "", false
+	}
+	return strings.Join(prefix, ".") + ".", true
+}
+
 func expandStability(stability string) string {
 	s := strings.ToLower(stability)
 	switch s {
@@ -168,8 +237,12 @@ func expandStability(stability string) string {
 	case "p", "pl":
 		return "patch"
 	case "rc":
-		return "rc"
+		return "RC"
 	default:
 		return s
 	}
+}
+
+func normalizeStability(stability string) string {
+	return expandStability(stability)
 }

--- a/normalizer_test.go
+++ b/normalizer_test.go
@@ -64,10 +64,10 @@ func TestNormalize(t *testing.T) {
 		{"1.0.0-a", "1.0.0.0-alpha"},
 		{"1.0.0-b", "1.0.0.0-beta"},
 		// Test RC Versions
-		{"1.0.0-RC1", "1.0.0.0-rc1"},
-		{"1.0.0RC1", "1.0.0.0-rc1"},
-		{"1.0.0-RC2", "1.0.0.0-rc2"},
-		{"1.0.0RC2", "1.0.0.0-rc2"},
+		{"1.0.0-RC1", "1.0.0.0-RC1"},
+		{"1.0.0RC1", "1.0.0.0-RC1"},
+		{"1.0.0-RC2", "1.0.0.0-RC2"},
+		{"1.0.0RC2", "1.0.0.0-RC2"},
 	}
 	for _, tt := range tests {
 		got, err := normalizeVersion(tt.input)

--- a/semver_behavior_test.go
+++ b/semver_behavior_test.go
@@ -1,0 +1,2604 @@
+package version
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// Some fixtures are derived from an external MIT-licensed semver test suite.
+// See EXTERNAL_TESTS_LICENSE.md for the source notice.
+func TestSemverExtendedSatisfies(t *testing.T) {
+	tests := []struct {
+		name       string
+		version    string
+		constraint string
+		expected   bool
+	}{
+		{name: "x wildcard major", version: "2.1.3", constraint: "2.x.x", expected: true},
+		{name: "x wildcard minor", version: "1.2.3", constraint: "1.2.x", expected: true},
+		{name: "x wildcard disjunction right", version: "2.1.3", constraint: "1.2.x || 2.x", expected: true},
+		{name: "x wildcard disjunction left", version: "1.2.3", constraint: "1.2.x || 2.x", expected: true},
+		{name: "x wildcard any", version: "1.2.3", constraint: "x", expected: true},
+		{name: "repeated star wildcard", version: "2.1.3", constraint: "2.*.*", expected: true},
+		{name: "segment star wildcard any", version: "1.2.3", constraint: "*.*", expected: true},
+		{name: "x wildcard wrong major", version: "1.1.3", constraint: "2.x.x", expected: false},
+		{name: "x wildcard wrong minor", version: "1.3.3", constraint: "1.2.x", expected: false},
+		{name: "repeated star wildcard wrong major", version: "1.1.3", constraint: "2.*.*", expected: false},
+		{name: "dev branch exact", version: "dev-master", constraint: "dev-master", expected: true},
+		{name: "dev branch arbitrary exact", version: "dev-feature-a", constraint: "dev-feature-a", expected: true},
+		{name: "numeric branch constraint", version: "1.0.9999999.9999999-dev", constraint: "1.0.x-dev", expected: true},
+		{name: "less-than excludes implicit stable prerelease", version: "1.0.0beta", constraint: "<1", expected: false},
+		{name: "less-than excludes prerelease of bound", version: "1.2.3-beta", constraint: "<1.2.3", expected: false},
+		{name: "tilde with v prefix and prerelease", version: "0.5.4-alpha", constraint: "~v0.5.4-beta", expected: false},
+		{name: "hyphen v major", version: "2.5.0", constraint: "v1 - v2", expected: true},
+		{name: "hyphen prerelease lower partial upper", version: "2.3.9", constraint: "1.2-beta - 2.3", expected: true},
+		{name: "hyphen prerelease lower partial upper stop", version: "2.4.0", constraint: "1.2-beta - 2.3", expected: false},
+		{name: "caret zero minor includes patch", version: "0.2.1", constraint: "^0.2.0", expected: true},
+		{name: "caret zero minor excludes next minor", version: "0.3.0", constraint: "^0.2.0", expected: false},
+		{name: "caret zero zero excludes next patch", version: "0.0.4", constraint: "^0.0.3", expected: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := checkSatisfiesForTest(tc.version, tc.constraint)
+			if err != nil {
+				t.Fatalf("unexpected parse error for version %q constraint %q: %v", tc.version, tc.constraint, err)
+			}
+			if actual != tc.expected {
+				t.Fatalf("constraint %q with version %q: expected %v, got %v", tc.constraint, tc.version, tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestSemverSatisfiesCases(t *testing.T) {
+	tests := []struct {
+		version    string
+		constraint string
+		expected   bool
+	}{
+		{"1.2.3", "1.0.0 - 2.0.0", true},
+		{"1.2.3", "^1.2.3+build", true},
+		{"1.3.0", "^1.2.3+build", true},
+		{"2.4.3-alpha", "1.2.3+asdf - 2.4.3+asdf", true},
+		{"1.3.0-beta", ">1.2", true},
+		{"1.2.3-beta", "<=1.2.3", true},
+		{"1.2.3-beta", "^1.2.3", true},
+		{"1.2.3", "1.2.3+asdf - 2.4.3+asdf", true},
+		{"1.0.0", "1.0.0", true},
+		{"1.2.3", "*", true},
+		{"v1.2.3", "*", true},
+		{"1.0.0", ">=1.0.0", true},
+		{"1.0.1", ">=1.0.0", true},
+		{"1.1.0", ">=1.0.0", true},
+		{"1.0.1", ">1.0.0", true},
+		{"1.1.0", ">1.0.0", true},
+		{"2.0.0", "<=2.0.0", true},
+		{"1.9999.9999", "<=2.0.0", true},
+		{"0.2.9", "<=2.0.0", true},
+		{"1.9999.9999", "<2.0.0", true},
+		{"0.2.9", "<2.0.0", true},
+		{"1.0.0", ">= 1.0.0", true},
+		{"1.0.1", ">=  1.0.0", true},
+		{"1.1.0", ">=   1.0.0", true},
+		{"1.0.1", "> 1.0.0", true},
+		{"1.1.0", ">  1.0.0", true},
+		{"2.0.0", "<=   2.0.0", true},
+		{"1.9999.9999", "<= 2.0.0", true},
+		{"0.2.9", "<=  2.0.0", true},
+		{"1.9999.9999", "<    2.0.0", true},
+		{"0.2.9", "<\t2.0.0", true},
+		{"v0.1.97", ">=0.1.97", true},
+		{"0.1.97", ">=0.1.97", true},
+		{"1.2.4", "0.1.20 || 1.2.4", true},
+		{"0.0.0", ">=0.2.3 || <0.0.1", true},
+		{"0.2.3", ">=0.2.3 || <0.0.1", true},
+		{"0.2.4", ">=0.2.3 || <0.0.1", true},
+		{"2.1.3", "2.x.x", true},
+		{"1.2.3", "1.2.x", true},
+		{"2.1.3", "1.2.x || 2.x", true},
+		{"1.2.3", "1.2.x || 2.x", true},
+		{"1.2.3", "x", true},
+		{"2.1.3", "2.*.*", true},
+		{"1.2.3", "1.2.*", true},
+		{"2.1.3", "1.2.* || 2.*", true},
+		{"1.2.3", "1.2.* || 2.*", true},
+		{"1.2.3", "*", true},
+		{"2.9.0", "~2.4", true},
+		{"2.4.5", "~2.4", true},
+		{"1.2.3", "~1", true},
+		{"1.4.7", "~1.0", true},
+		{"1.0.0", ">=1", true},
+		{"1.0.0", ">= 1", true},
+		{"1.2.8", ">1.2", true},
+		{"1.1.1", "<1.2", true},
+		{"1.1.1", "< 1.2", true},
+		{"1.2.3", "~1.2.1 >=1.2.3", true},
+		{"1.2.3", "~1.2.1 =1.2.3", true},
+		{"1.2.3", "~1.2.1 1.2.3", true},
+		{"1.2.3", "~1.2.1 >=1.2.3 1.2.3", true},
+		{"1.2.3", "~1.2.1 1.2.3 >=1.2.3", true},
+		{"1.2.3", "~1.2.1 1.2.3", true},
+		{"1.2.3", ">=1.2.1 1.2.3", true},
+		{"1.2.3", "1.2.3 >=1.2.1", true},
+		{"1.2.3", ">=1.2.3 >=1.2.1", true},
+		{"1.2.3", ">=1.2.1 >=1.2.3", true},
+		{"1.2.8", ">=1.2", true},
+		{"1.8.1", "^1.2.3", true},
+		{"0.1.2", "^0.1.2", true},
+		{"0.1.2", "^0.1", true},
+		{"1.4.2", "^1.2", true},
+		{"1.4.2", "^1.2 ^1", true},
+		{"0.0.1-beta", "^0.0.1-alpha", true},
+		{"2.2.3", "1.0.0 - 2.0.0", false},
+		{"2.0.0", "^1.2.3+build", false},
+		{"1.2.0", "^1.2.3+build", false},
+		{"1.0.0beta", "1", false},
+		{"1.0.0beta", "<1", false},
+		{"1.0.0beta", "< 1", false},
+		{"1.0.1", "1.0.0", false},
+		{"0.0.0", ">=1.0.0", false},
+		{"0.0.1", ">=1.0.0", false},
+		{"0.1.0", ">=1.0.0", false},
+		{"0.0.1", ">1.0.0", false},
+		{"0.1.0", ">1.0.0", false},
+		{"3.0.0", "<=2.0.0", false},
+		{"2.9999.9999", "<=2.0.0", false},
+		{"2.2.9", "<=2.0.0", false},
+		{"2.9999.9999", "<2.0.0", false},
+		{"2.2.9", "<2.0.0", false},
+		{"v0.1.93", ">=0.1.97", false},
+		{"0.1.93", ">=0.1.97", false},
+		{"1.2.3", "0.1.20 || 1.2.4", false},
+		{"0.0.3", ">=0.2.3 || <0.0.1", false},
+		{"0.2.2", ">=0.2.3 || <0.0.1", false},
+		{"1.1.3", "2.x.x", false},
+		{"3.1.3", "2.x.x", false},
+		{"1.3.3", "1.2.x", false},
+		{"3.1.3", "1.2.x || 2.x", false},
+		{"1.1.3", "1.2.x || 2.x", false},
+		{"1.1.3", "2.*.*", false},
+		{"3.1.3", "2.*.*", false},
+		{"1.3.3", "1.2.*", false},
+		{"3.1.3", "1.2.* || 2.*", false},
+		{"1.1.3", "1.2.* || 2.*", false},
+		{"1.1.2", "2", false},
+		{"2.4.1", "2.3", false},
+		{"3.0.0", "~2.4", false},
+		{"2.3.9", "~2.4", false},
+		{"0.2.3", "~1", false},
+		{"1.0.0", "<1", false},
+		{"1.1.1", ">=1.2", false},
+		{"2.0.0beta", "1", false},
+		{"0.5.4-alpha", "~v0.5.4-beta", false},
+		{"1.2.3-beta", "<1.2.3", false},
+		{"2.0.0-alpha", "^1.2.3", false},
+		{"1.2.2", "^1.2.3", false},
+		{"1.1.9", "^1.2", false},
+	}
+
+	for _, tc := range tests {
+		actual, err := checkSatisfiesForTest(tc.version, tc.constraint)
+		if err != nil {
+			t.Errorf("Satisfies(%q, %q) unexpected error: %v", tc.version, tc.constraint, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("Satisfies(%q, %q): expected %v, got %v", tc.version, tc.constraint, tc.expected, actual)
+		}
+	}
+}
+
+func TestSemverNormalize(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "none", input: "1.0.0", expected: "1.0.0.0"},
+		{name: "none/2", input: "1.2.3.4", expected: "1.2.3.4"},
+		{name: "parses state", input: "1.0.0RC1dev", expected: "1.0.0.0-RC1-dev"},
+		{name: "rc uppercase", input: "1.0.0-rc1", expected: "1.0.0.0-RC1"},
+		{name: "rc case insensitive", input: "1.0.0-rC15-dev", expected: "1.0.0.0-RC15-dev"},
+		{name: "rc dotted delimiters", input: "1.0.0.RC.15-dev", expected: "1.0.0.0-RC15-dev"},
+		{name: "patch shorthand", input: "1.0.0.pl3-dev", expected: "1.0.0.0-patch3-dev"},
+		{name: "forces w.x.y.z", input: "1.0-dev", expected: "1.0.0.0-dev"},
+		{name: "forces w.x.y.z/2", input: "0", expected: "0.0.0.0"},
+		{name: "forces w.x.y.z/maximum major", input: "99999", expected: "99999.0.0.0"},
+		{name: "parses long", input: "10.4.13-beta", expected: "10.4.13.0-beta"},
+		{name: "parses long/2", input: "10.4.13beta2", expected: "10.4.13.0-beta2"},
+		{name: "parses long/semver", input: "10.4.13beta.2", expected: "10.4.13.0-beta2"},
+		{name: "parses long/semver2", input: "v1.13.11-beta.0", expected: "1.13.11.0-beta0"},
+		{name: "parses long/semver3", input: "1.13.11.0-beta0", expected: "1.13.11.0-beta0"},
+		{name: "expand shorthand", input: "10.4.13-b", expected: "10.4.13.0-beta"},
+		{name: "expand shorthand/2", input: "10.4.13-b5", expected: "10.4.13.0-beta5"},
+		{name: "strips leading v", input: "v1.0.0", expected: "1.0.0.0"},
+		{name: "parses dates y-m as classical", input: "2010.01", expected: "2010.01.0.0"},
+		{name: "parses dates w/ . as classical", input: "2010.01.02", expected: "2010.01.02.0"},
+		{name: "parses dates y.m.Y as classical", input: "2010.1.555", expected: "2010.1.555.0"},
+		{name: "parses dates y.m.Y/2 as classical", input: "2010.10.200", expected: "2010.10.200.0"},
+		{name: "parses CalVer YYYYMMDD (as MAJOR) versions", input: "20230131.0.0", expected: "20230131.0.0"},
+		{name: "parses CalVer YYYYMMDDhhmm (as MAJOR) versions", input: "202301310000.0.0", expected: "202301310000.0.0"},
+		{name: "strips v/datetime", input: "v20100102", expected: "20100102"},
+		{name: "parses dates no delimiter", input: "20100102", expected: "20100102"},
+		{name: "parses dates no delimiter/2", input: "20100102.0", expected: "20100102.0"},
+		{name: "parses dates no delimiter/3", input: "20100102.1.0", expected: "20100102.1.0"},
+		{name: "parses dates no delimiter/4", input: "20100102.0.3", expected: "20100102.0.3"},
+		{name: "parses dates no delimiter/earliest year", input: "100000", expected: "100000"},
+		{name: "parses dates w/ - and .", input: "2010-01-02-10-20-30.0.3", expected: "2010.01.02.10.20.30.0.3"},
+		{name: "parses dates w/ - and ./2", input: "2010-01-02-10-20-30.5", expected: "2010.01.02.10.20.30.5"},
+		{name: "parses dates w/ -", input: "2010-01-02", expected: "2010.01.02"},
+		{name: "parses dates w/ .", input: "2012.06.07", expected: "2012.06.07.0"},
+		{name: "parses numbers", input: "2010-01-02.5", expected: "2010.01.02.5"},
+		{name: "parses dates y.m.Y", input: "2010.1.555", expected: "2010.1.555.0"},
+		{name: "parses datetime", input: "20100102-203040", expected: "20100102.203040"},
+		{name: "parses date dev", input: "20100102.x-dev", expected: "20100102.9999999.9999999.9999999-dev"},
+		{name: "parses datetime dev", input: "20100102.203040.x-dev", expected: "20100102.203040.9999999.9999999-dev"},
+		{name: "parses dt+number", input: "20100102203040-10", expected: "20100102203040.10"},
+		{name: "parses dt+patch", input: "20100102-203040-p1", expected: "20100102.203040-patch1"},
+		{name: "parses dt Ym", input: "201903.0", expected: "201903.0"},
+		{name: "parses dt Ym dev", input: "201903.x-dev", expected: "201903.9999999.9999999.9999999-dev"},
+		{name: "parses dt Ym+patch", input: "201903.0-p2", expected: "201903.0-patch2"},
+		{name: "parses master", input: "dev-master", expected: "dev-master"},
+		{name: "parses master w/o dev", input: "master", expected: "dev-master"},
+		{name: "parses trunk", input: "dev-trunk", expected: "dev-trunk"},
+		{name: "parses branches", input: "1.x-dev", expected: "1.9999999.9999999.9999999-dev"},
+		{name: "parses arbitrary", input: "dev-feature-foo", expected: "dev-feature-foo"},
+		{name: "parses arbitrary/2", input: "DEV-FOOBAR", expected: "dev-FOOBAR"},
+		{name: "parses arbitrary/3", input: "dev-feature/foo", expected: "dev-feature/foo"},
+		{name: "parses arbitrary/4", input: "dev-feature+issue-1", expected: "dev-feature+issue-1"},
+		{name: "ignores aliases", input: "dev-master as 1.0.0", expected: "dev-master"},
+		{name: "ignores aliases/2", input: "dev-load-varnish-only-when-used as ^2.0", expected: "dev-load-varnish-only-when-used"},
+		{name: "ignores aliases/3", input: "dev-load-varnish-only-when-used@dev as ^2.0@dev", expected: "dev-load-varnish-only-when-used"},
+		{name: "ignores stability", input: "1.0.0+foo@dev", expected: "1.0.0.0"},
+		{name: "ignores stability/2", input: "dev-load-varnish-only-when-used@stable", expected: "dev-load-varnish-only-when-used"},
+		{name: "semver beta metadata", input: "1.0.0-beta.5+foo", expected: "1.0.0.0-beta5"},
+		{name: "semver metadata/3", input: "1.0.0+foo", expected: "1.0.0.0"},
+		{name: "semver alpha dotted metadata", input: "1.0.0-alpha.3.1+foo", expected: "1.0.0.0-alpha3.1"},
+		{name: "semver metadata/5", input: "1.0.0-alpha2.1+foo", expected: "1.0.0.0-alpha2.1"},
+		{name: "semver alpha dashed metadata", input: "1.0.0-alpha-2.1-3+foo", expected: "1.0.0.0-alpha2.1-3"},
+		{name: "metadata w/ alias", input: "1.0.0+foo as 2.0", expected: "1.0.0.0"},
+		{name: "keep zero-padding", input: "00.01.03.04", expected: "00.01.03.04"},
+		{name: "keep zero-padding/2", input: "000.001.003.004", expected: "000.001.003.004"},
+		{name: "keep zero-padding/3", input: "0.000.103.204", expected: "0.000.103.204"},
+		{name: "keep zero-padding/4", input: "0700", expected: "0700.0.0.0"},
+		{name: "keep zero-padding/5", input: "041.x-dev", expected: "041.9999999.9999999.9999999-dev"},
+		{name: "keep zero-padding/6", input: "dev-041.003", expected: "dev-041.003"},
+		{name: "dev with mad name", input: "dev-1.0.0-dev<1.0.5-dev", expected: "dev-1.0.0-dev<1.0.5-dev"},
+		{name: "dev prefix with spaces", input: "dev-foo bar", expected: "dev-foo bar"},
+		{name: "space padding", input: " 1.0.0", expected: "1.0.0.0"},
+		{name: "space padding/2", input: "1.0.0 ", expected: "1.0.0.0"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := normalizeVersion(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected normalize error for %q: %v", tc.input, err)
+			}
+			if actual != tc.expected {
+				t.Fatalf("normalize %q: expected %q, got %q", tc.input, tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestSemverNormalizeFailsCases(t *testing.T) {
+	tests := []string{
+		"",
+		"a",
+		"1.0.0-meh",
+		"1.0.0.0.0",
+		"feature-foo",
+		"1.0.0+foo bar",
+		"1.0.1-SNAPSHOT",
+		"1.0.0<1.0.5-dev",
+		"1.0.0-dev<1.0.5-dev",
+		"foo bar-dev",
+		"1.0 .2",
+		" as ",
+		" as 1.2",
+		"^",
+		"^8 || ^",
+		"~",
+		"~1 ~",
+		"~1",
+		"^1",
+		"1.*",
+		"20100102.0.3.4",
+		"100000.0.0.0",
+		"2023013.0.0",
+		"202301311.0.0",
+		"20230131000.0.0",
+		"2023013100000.0.0",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			if actual, err := normalizeVersion(input); err == nil {
+				t.Fatalf("expected normalizeVersion(%q) to fail, got %q", input, actual)
+			}
+		})
+	}
+}
+
+func TestSemverNormalizeAliasErrorCases(t *testing.T) {
+	badAliases := []struct {
+		full   string
+		source string
+		alias  string
+	}{
+		{"1.0.0+foo as ^2.0", "1.0.0+foo", "^2.0"},
+		{"1.0.0+foo as  ~2.0", "1.0.0+foo", "~2.0"},
+		{"1.0.0+foo  as >2.0", "1.0.0+foo", ">2.0"},
+		{"1.0.0+foo as <2.0", "1.0.0+foo", "<2.0"},
+		{"1.0.0+foo@dev as <2.0@dev", "1.0.0+foo@dev", "<2.0@dev"},
+	}
+
+	for _, tc := range badAliases {
+		if _, err := normalizeVersionWithContext(tc.source, tc.full); err != nil {
+			t.Errorf("normalizeVersionWithContext(%q, %q) unexpected source error: %v", tc.source, tc.full, err)
+			continue
+		}
+
+		_, err := normalizeVersionWithContext(tc.alias, tc.full)
+		expected := fmt.Sprintf(`invalid version string "%s" in "%s", the alias must be an exact version`, tc.alias, tc.full)
+		if err == nil || err.Error() != expected {
+			t.Errorf("normalizeVersionWithContext(%q, %q): expected error %q, got %v", tc.alias, tc.full, expected, err)
+		}
+	}
+
+	badAliasees := []struct {
+		full   string
+		source string
+		alias  string
+	}{
+		{"^2.0 as 1.0.0+foo", "^2.0", "1.0.0+foo"},
+		{"~2.0 as  1.0.0+foo", "~2.0", "1.0.0+foo"},
+		{">2.0  as 1.0.0+foo", ">2.0", "1.0.0+foo"},
+		{"<2.0 as 1.0.0+foo", "<2.0", "1.0.0+foo"},
+		{"<2.0@dev as 1.2.3@dev", "<2.0@dev", "1.2.3@dev"},
+	}
+
+	for _, tc := range badAliasees {
+		_, err := normalizeVersionWithContext(tc.source, tc.full)
+		expected := fmt.Sprintf(`invalid version string "%s" in "%s", the alias source must be an exact version, if it is a branch name you should prefix it with dev-`, tc.source, tc.full)
+		if err == nil || err.Error() != expected {
+			t.Errorf("normalizeVersionWithContext(%q, %q): expected error %q, got %v", tc.source, tc.full, expected, err)
+		}
+
+		if _, err := normalizeVersionWithContext(tc.alias, tc.full); err != nil {
+			t.Errorf("normalizeVersionWithContext(%q, %q) unexpected alias error: %v", tc.alias, tc.full, err)
+		}
+	}
+}
+
+func TestSemverNormalizeBranchCases(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"v1.x", "1.9999999.9999999.9999999-dev"},
+		{"v1.*", "1.9999999.9999999.9999999-dev"},
+		{"v1.0", "1.0.9999999.9999999-dev"},
+		{"2.0", "2.0.9999999.9999999-dev"},
+		{"v1.0.x", "1.0.9999999.9999999-dev"},
+		{"v1.0.3.*", "1.0.3.9999999-dev"},
+		{"v2.4.0", "2.4.0.9999999-dev"},
+		{"2.4.4", "2.4.4.9999999-dev"},
+		{"master", "dev-master"},
+		{"trunk", "dev-trunk"},
+		{"feature-a", "dev-feature-a"},
+		{"FOOBAR", "dev-FOOBAR"},
+		{"feature+issue-1", "dev-feature+issue-1"},
+	}
+
+	for _, tc := range tests {
+		if actual := normalizeBranch(tc.input); actual != tc.expected {
+			t.Errorf("normalizeBranch(%q): expected %q, got %q", tc.input, tc.expected, actual)
+		}
+	}
+}
+
+func TestSemverNumericAliasPrefixCases(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+		ok       bool
+	}{
+		{"0.x-dev", "0.", true},
+		{"1.0.x-dev", "1.0.", true},
+		{"1.x-dev", "1.", true},
+		{"1.2.x-dev", "1.2.", true},
+		{"1.2-dev", "1.2.", true},
+		{"1-dev", "1.", true},
+		{"dev-develop", "", false},
+		{"dev-master", "", false},
+	}
+
+	for _, tc := range tests {
+		actual, ok := parseNumericAliasPrefix(tc.input)
+		if actual != tc.expected || ok != tc.ok {
+			t.Errorf("parseNumericAliasPrefix(%q): expected (%q, %v), got (%q, %v)", tc.input, tc.expected, tc.ok, actual, ok)
+		}
+	}
+}
+
+func TestSemverIsValidCases(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"0.x-dev", true},
+		{"dev-develop", true},
+		{"1.0.2", true},
+		{"1.0.2.5", true},
+		{"1.0.2.5.5", false},
+		{"foo", false},
+	}
+
+	for _, tc := range tests {
+		_, err := NewVersion(tc.input)
+		if actual := err == nil; actual != tc.expected {
+			t.Errorf("isValid(%q): expected %v, got %v (err: %v)", tc.input, tc.expected, actual, err)
+		}
+	}
+}
+
+func TestSemverComparatorCases(t *testing.T) {
+	tests := []struct {
+		version1 string
+		operator string
+		version2 string
+		expected bool
+	}{
+		{"1.25.0", ">", "1.24.0", true},
+		{"1.25.0", ">", "1.25.0", false},
+		{"1.25.0", ">", "1.26.0", false},
+		{"1.26.0", ">", "dev-foo", true},
+		{"dev-foo", ">", "dev-master", false},
+		{"dev-foo", ">", "dev-bar", false},
+		{"1.25.0", ">=", "1.24.0", true},
+		{"1.25.0", ">=", "1.25.0", true},
+		{"1.25.0", ">=", "1.26.0", false},
+		{"1.25.0", "<", "1.24.0", false},
+		{"1.25.0", "<", "1.25.0", false},
+		{"1.25.0", "<", "1.26.0", true},
+		{"1.0.0", "<", "1.2-dev", true},
+		{"dev-foo", "<", "1.26.0", true},
+		{"dev-foo", "<", "dev-master", false},
+		{"dev-foo", "<", "dev-bar", false},
+		{"1.25.0", "<=", "1.24.0", false},
+		{"1.25.0", "<=", "1.25.0", true},
+		{"1.25.0", "<=", "1.26.0", true},
+		{"1.25.0", "==", "1.24.0", false},
+		{"1.25.0", "==", "1.25.0", true},
+		{"1.25.0", "==", "1.26.0", false},
+		{"dev-foo", "==", "1.26.0", false},
+		{"dev-foo", "==", "dev-master", false},
+		{"dev-foo", "==", "dev-bar", false},
+		{"1.25.0", "!=", "1.24.0", true},
+		{"1.25.0", "!=", "1.25.0", false},
+		{"1.25.0", "!=", "1.26.0", true},
+		{"1.25.0-beta2.1", "<", "1.25.0-b.3", true},
+		{"1.25.0-b2.1", "<", "1.25.0beta.3", true},
+		{"1.25.0-b-2.1", "<", "1.25.0-rc", true},
+		{"1.25.0-beta2.1", "==", "1.25.0-b.2.1", true},
+		{"1.25.0beta2.1", "==", "1.25.0-b2.1", true},
+		{"1.25.0", "=", "1.24.0", false},
+		{"1.25.0", "=", "1.25.0", true},
+		{"1.25.0", "=", "1.26.0", false},
+		{"1.25.0", "<>", "1.24.0", true},
+		{"1.25.0", "<>", "1.25.0", false},
+		{"1.25.0", "<>", "1.26.0", true},
+	}
+
+	for _, tc := range tests {
+		actual, err := compareForTest(tc.version1, tc.operator, tc.version2)
+		if err != nil {
+			t.Errorf("compare(%q, %q, %q) unexpected error: %v", tc.version1, tc.operator, tc.version2, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("compare(%q, %q, %q): expected %v, got %v", tc.version1, tc.operator, tc.version2, tc.expected, actual)
+		}
+	}
+}
+
+func TestConstraintInvalidComparatorOperator(t *testing.T) {
+	if _, err := compareForTest("1.1", "!==", "1.2"); err == nil {
+		t.Fatal("expected invalid comparator operator to be rejected")
+	}
+}
+
+func TestSemverSortCases(t *testing.T) {
+	tests := []struct {
+		versions []string
+		sorted   []string
+		rsorted  []string
+	}{
+		{
+			[]string{"1.0", "0.1", "0.1", "3.2.1", "2.4.0-alpha", "2.4.0"},
+			[]string{"0.1", "0.1", "1.0", "2.4.0-alpha", "2.4.0", "3.2.1"},
+			[]string{"3.2.1", "2.4.0", "2.4.0-alpha", "1.0", "0.1", "0.1"},
+		},
+		{
+			[]string{"dev-foo", "dev-master", "1.0", "50.2"},
+			[]string{"dev-foo", "1.0", "50.2", "dev-master"},
+			[]string{"dev-master", "50.2", "1.0", "dev-foo"},
+		},
+	}
+
+	for _, tc := range tests {
+		versions := mustVersions(t, tc.versions)
+		sort.Sort(Collection(versions))
+		if actual := versionOriginals(versions); !equalStrings(actual, tc.sorted) {
+			t.Errorf("sort(%v): expected %v, got %v", tc.versions, tc.sorted, actual)
+		}
+
+		versions = mustVersions(t, tc.versions)
+		sort.Sort(sort.Reverse(Collection(versions)))
+		if actual := versionOriginals(versions); !equalStrings(actual, tc.rsorted) {
+			t.Errorf("rsort(%v): expected %v, got %v", tc.versions, tc.rsorted, actual)
+		}
+	}
+}
+
+func TestSemverSatisfiedByCases(t *testing.T) {
+	tests := []struct {
+		constraint string
+		versions   []string
+		expected   []string
+	}{
+		{
+			"~1.0",
+			[]string{"1.0", "1.2", "1.9999.9999", "2.0", "2.1", "0.9999.9999"},
+			[]string{"1.0", "1.2", "1.9999.9999"},
+		},
+		{
+			">1.0 <3.0 || >=4.0",
+			[]string{"1.0", "1.1", "2.9999.9999", "3.0", "3.1", "3.9999.9999", "4.0", "4.1"},
+			[]string{"1.1", "2.9999.9999", "4.0", "4.1"},
+		},
+		{
+			"^0.2.0",
+			[]string{"0.1.1", "0.1.9999", "0.2.0", "0.2.1", "0.3.0"},
+			[]string{"0.2.0", "0.2.1"},
+		},
+	}
+
+	for _, tc := range tests {
+		actual, err := satisfiedByForTest(tc.constraint, tc.versions)
+		if err != nil {
+			t.Errorf("satisfiedBy(%q, %v) unexpected error: %v", tc.constraint, tc.versions, err)
+			continue
+		}
+		if !equalStrings(actual, tc.expected) {
+			t.Errorf("satisfiedBy(%q, %v): expected %v, got %v", tc.constraint, tc.versions, tc.expected, actual)
+		}
+	}
+}
+
+func TestSemverStabilityCases(t *testing.T) {
+	tests := []struct {
+		expected string
+		version  string
+	}{
+		{"stable", "1"},
+		{"stable", "1.0"},
+		{"stable", "3.2.1"},
+		{"stable", "v3.2.1"},
+		{"dev", "v2.0.x-dev"},
+		{"dev", "v2.0.x-dev#abc123"},
+		{"dev", "v2.0.x-dev#trunk/@123"},
+		{"RC", "3.0-RC2"},
+		{"dev", "dev-master"},
+		{"dev", "3.1.2-dev"},
+		{"dev", "dev-feature+issue-1"},
+		{"stable", "3.1.2-p1"},
+		{"stable", "3.1.2-pl2"},
+		{"stable", "3.1.2-patch"},
+		{"alpha", "3.1.2-alpha5"},
+		{"beta", "3.1.2-beta"},
+		{"beta", "2.0B1"},
+		{"alpha", "1.2.0a1"},
+		{"alpha", "1.2_a1"},
+		{"RC", "2.0.0rc1"},
+		{"alpha", "1.0.0-alpha11+cs-1.1.0"},
+		{"dev", "1-2_dev"},
+	}
+
+	for _, tc := range tests {
+		if actual := Stability(tc.version); actual != tc.expected {
+			t.Errorf("Stability(%q): expected %q, got %q", tc.version, tc.expected, actual)
+		}
+	}
+}
+
+func TestSemverNormalizeStability(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"rc", "RC"},
+		{"BeTa", "beta"},
+	}
+
+	for _, tc := range tests {
+		if actual := normalizeStability(tc.input); actual != tc.expected {
+			t.Errorf("normalizeStability(%q): expected %q, got %q", tc.input, tc.expected, actual)
+		}
+	}
+}
+
+func TestSemverRangeCases(t *testing.T) {
+	tests := []struct {
+		version    string
+		constraint string
+		expected   bool
+	}{
+		{"2.5.0", "v2.*", true},
+		{"3.0.0", "v2.*", false},
+		{"2.5.0", "2.*.*", true},
+		{"3.0.0", "2.*.*", false},
+		{"20.5.0", "20.*", true},
+		{"21.0.0", "20.*", false},
+		{"20.5.0", "20.*.*", true},
+		{"21.0.0", "20.*.*", false},
+		{"2.0.5", "2.0.*", true},
+		{"2.1.0", "2.0.*", false},
+		{"2.5.0", "2.x", true},
+		{"3.0.0", "2.x", false},
+		{"2.5.0", "2.x.x", true},
+		{"3.0.0", "2.x.x", false},
+		{"2.2.9", "2.2.x", true},
+		{"2.3.0", "2.2.x", false},
+		{"2.10.9", "2.10.X", true},
+		{"2.11.0", "2.10.X", false},
+		{"2.1.3.5", "2.1.3.*", true},
+		{"2.1.4.0", "2.1.3.*", false},
+		{"0.5.0", "0.*", true},
+		{"1.0.0", "0.*", false},
+		{"0.5.0", "0.*.*", true},
+		{"1.0.0", "0.*.*", false},
+		{"0.5.0", "0.x", true},
+		{"1.0.0", "0.x", false},
+		{"0.5.0", "0.x.x", true},
+		{"1.0.0", "0.x.x", false},
+		{"1.5.0", "~v1", true},
+		{"2.0.0", "~v1", false},
+		{"1.5.0", "~1.0", true},
+		{"2.0.0", "~1.0", false},
+		{"1.0.9", "~1.0.0", true},
+		{"1.1.0", "~1.0.0", false},
+		{"1.9.9", "~1.2", true},
+		{"2.0.0", "~1.2", false},
+		{"1.2.9", "~1.2.3", true},
+		{"1.3.0", "~1.2.3", false},
+		{"1.2.3.5", "~1.2.3.4", true},
+		{"1.2.4.0", "~1.2.3.4", false},
+		{"1.9.9", "~1.2-beta", true},
+		{"2.0.0", "~1.2-beta", false},
+		{"1.2.0-beta2", "~1.2-BETA2", true},
+		{"1.2.0-beta1", "~1.2-BETA2", false},
+		{"1.2.2-dev", "~1.2.2-dev", true},
+		{"1.3.0-dev", "~1.2.2-dev", false},
+		{"1.2.2", "~1.2.2-stable", true},
+		{"1.2.2-RC1", "~1.2.2-stable", false},
+		{"201903.10", "~201903.0", true},
+		{"201904.0.0.0-dev", "~201903.0", false},
+		{"201903.0-beta", "~201903.0-beta", true},
+		{"201903.0-alpha", "~201903.0-beta", false},
+		{"201903.0", "~201903.0-stable", true},
+		{"201903.0-RC1", "~201903.0-stable", false},
+		{"201903.205830.1", "~201903.205830.1-stable", true},
+		{"201903.205831.0.0-dev", "~201903.205830.1-stable", false},
+		{"2.9999999.9999999.9999999-dev", "~2.x-dev", true},
+		{"3.0.0.0-dev", "~2.x-dev", false},
+		{"2.0.9999999.9999999-dev", "~2.0.x-dev", true},
+		{"2.1.0.0-dev", "~2.0.x-dev", false},
+		{"2.0.3.9999999-dev", "~2.0.3.x-dev", true},
+		{"2.0.4.0-dev", "~2.0.3.x-dev", false},
+		{"0.9999999.9999999.9999999-dev", "~0.x-dev", true},
+		{"1.0.0.0-dev", "~0.x-dev", false},
+		{"1.5.0", "^v1", true},
+		{"2.0.0", "^v1", false},
+		{"0.5.0", "^0", true},
+		{"1.0.0", "^0", false},
+		{"0.0.5", "^0.0", true},
+		{"0.1.0", "^0.0", false},
+		{"1.9.9", "^1.2", true},
+		{"2.0.0", "^1.2", false},
+		{"1.2.3-beta2", "^1.2.3-beta.2", true},
+		{"1.2.3-beta1", "^1.2.3-beta.2", false},
+		{"1.2.3.5", "^1.2.3.4", true},
+		{"2.0.0", "^1.2.3.4", false},
+		{"1.9.9", "^1.2.3", true},
+		{"2.0.0", "^1.2.3", false},
+		{"0.2.9", "^0.2.3", true},
+		{"0.3.0", "^0.2.3", false},
+		{"0.2.9", "^0.2", true},
+		{"0.3.0", "^0.2", false},
+		{"0.2.9", "^0.2.0", true},
+		{"0.3.0", "^0.2.0", false},
+		{"0.0.3", "^0.0.3", true},
+		{"0.0.4", "^0.0.3", false},
+		{"0.0.3-alpha", "^0.0.3-alpha", true},
+		{"0.0.4-dev", "^0.0.3-alpha", false},
+		{"0.0.3-dev", "^0.0.3-dev", true},
+		{"0.0.4-dev", "^0.0.3-dev", false},
+		{"0.0.3", "^0.0.3-stable", true},
+		{"0.0.3-RC1", "^0.0.3-stable", false},
+		{"201903.10", "^201903.0", true},
+		{"201904.0.0.0-dev", "^201903.0", false},
+		{"201903.0-beta", "^201903.0-beta", true},
+		{"201903.0-alpha", "^201903.0-beta", false},
+		{"201903.205830.1", "^201903.205830.1-stable", true},
+		{"201904.0.0.0-dev", "^201903.205830.1-stable", false},
+		{"2.0.9999999.9999999-dev", "^2.0.x-dev", true},
+		{"3.0.0.0-dev", "^2.0.x-dev", false},
+		{"2.0.9999999.9999999-dev", "^2.0.*-dev", true},
+		{"3.0.0.0-dev", "^2.0.*-dev", false},
+		{"2.0.3.9999999-dev", "^2.0.3.x-dev", true},
+		{"3.0.0.0-dev", "^2.0.3.x-dev", false},
+		{"2.9999999.9999999.9999999-dev", "^2.x-dev", true},
+		{"3.0.0.0-dev", "^2.x-dev", false},
+		{"0.9999999.9999999.9999999-dev", "^0.x-dev", true},
+		{"1.0.0.0-dev", "^0.x-dev", false},
+		{"2.5.0", "v1 - v2", true},
+		{"3.0.0", "v1 - v2", false},
+		{"2.3.4.5", "1.2.3 - 2.3.4.5", true},
+		{"2.3.4.6", "1.2.3 - 2.3.4.5", false},
+		{"2.3.9", "1.2-beta - 2.3", true},
+		{"2.4.0.0-dev", "1.2-beta - 2.3", false},
+		{"2.3.0-dev", "1.2-beta - 2.3-dev", true},
+		{"2.3.0", "1.2-beta - 2.3-dev", false},
+		{"2.3.1", "1.2-RC - 2.3.1", true},
+		{"2.3.1.1", "1.2-RC - 2.3.1", false},
+		{"2.3.0-RC", "1.2.3-alpha - 2.3-RC", true},
+		{"2.3.0", "1.2.3-alpha - 2.3-RC", false},
+		{"2.0.9", "1 - 2.0", true},
+		{"2.1.0.0-dev", "1 - 2.0", false},
+		{"2.1.9", "1 - 2.1", true},
+		{"2.2.0.0-dev", "1 - 2.1", false},
+		{"2.1.0", "1.2 - 2.1.0", true},
+		{"2.1.0.1", "1.2 - 2.1.0", false},
+		{"2.1.3", "1.3 - 2.1.3", true},
+		{"2.1.3.1", "1.3 - 2.1.3", false},
+		{"3.0.3.9999999-dev", "2.0.3.x-dev - 3.0.3.x-dev", true},
+		{"3.0.4.0-dev", "2.0.3.x-dev - 3.0.3.x-dev", false},
+		{"3.0.9999999.9999999-dev", "2.0.x-dev - 3.0.x-dev", true},
+		{"3.1.0.0-dev", "2.0.x-dev - 3.0.x-dev", false},
+		{"3.9999999.9999999.9999999-dev", "2.x-dev - 3.x-dev", true},
+		{"4.0.0.0-dev", "2.x-dev - 3.x-dev", false},
+		{"1.9999999.9999999.9999999-dev", "0.x-dev - 1.x-dev", true},
+		{"2.0.0.0-dev", "0.x-dev - 1.x-dev", false},
+	}
+
+	for _, tc := range tests {
+		actual, err := checkSatisfiesForTest(tc.version, tc.constraint)
+		if err != nil {
+			t.Errorf("Satisfies(%q, %q) unexpected error: %v", tc.version, tc.constraint, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("Satisfies(%q, %q): expected %v, got %v", tc.version, tc.constraint, tc.expected, actual)
+		}
+	}
+}
+
+func TestVersionParserRangeSnapshots(t *testing.T) {
+	noDev := branchSnapshot{Names: []string{}}
+	tests := []struct {
+		name       string
+		constraint string
+		start      string
+		end        string
+	}{
+		{"wildcard v2.*", "v2.*", ">= 2.0.0.0-dev", "< 3.0.0.0-dev"},
+		{"wildcard 2.*.*", "2.*.*", ">= 2.0.0.0-dev", "< 3.0.0.0-dev"},
+		{"wildcard 20.*", "20.*", ">= 20.0.0.0-dev", "< 21.0.0.0-dev"},
+		{"wildcard 20.*.*", "20.*.*", ">= 20.0.0.0-dev", "< 21.0.0.0-dev"},
+		{"wildcard 2.0.*", "2.0.*", ">= 2.0.0.0-dev", "< 2.1.0.0-dev"},
+		{"wildcard 2.x", "2.x", ">= 2.0.0.0-dev", "< 3.0.0.0-dev"},
+		{"wildcard 2.x.x", "2.x.x", ">= 2.0.0.0-dev", "< 3.0.0.0-dev"},
+		{"wildcard 2.2.x", "2.2.x", ">= 2.2.0.0-dev", "< 2.3.0.0-dev"},
+		{"wildcard 2.10.X", "2.10.X", ">= 2.10.0.0-dev", "< 2.11.0.0-dev"},
+		{"wildcard 2.1.3.*", "2.1.3.*", ">= 2.1.3.0-dev", "< 2.1.4.0-dev"},
+		{"wildcard 0.*", "0.*", ">= 0.0.0.0-dev", "< 1.0.0.0-dev"},
+		{"wildcard 0.*.*", "0.*.*", ">= 0.0.0.0-dev", "< 1.0.0.0-dev"},
+		{"wildcard 0.x", "0.x", ">= 0.0.0.0-dev", "< 1.0.0.0-dev"},
+		{"wildcard 0.x.x", "0.x.x", ">= 0.0.0.0-dev", "< 1.0.0.0-dev"},
+		{"tilde ~v1", "~v1", ">= 1.0.0.0-dev", "< 2.0.0.0-dev"},
+		{"tilde ~1.0", "~1.0", ">= 1.0.0.0-dev", "< 2.0.0.0-dev"},
+		{"tilde ~1.0.0", "~1.0.0", ">= 1.0.0.0-dev", "< 1.1.0.0-dev"},
+		{"tilde ~1.2", "~1.2", ">= 1.2.0.0-dev", "< 2.0.0.0-dev"},
+		{"tilde ~1.2.3", "~1.2.3", ">= 1.2.3.0-dev", "< 1.3.0.0-dev"},
+		{"tilde ~1.2.3.4", "~1.2.3.4", ">= 1.2.3.4-dev", "< 1.2.4.0-dev"},
+		{"tilde ~1.2-beta", "~1.2-beta", ">= 1.2.0.0-beta", "< 2.0.0.0-dev"},
+		{"tilde ~1.2-b2", "~1.2-b2", ">= 1.2.0.0-beta2", "< 2.0.0.0-dev"},
+		{"tilde ~1.2-BETA2", "~1.2-BETA2", ">= 1.2.0.0-beta2", "< 2.0.0.0-dev"},
+		{"tilde ~1.2.2-dev", "~1.2.2-dev", ">= 1.2.2.0-dev", "< 1.3.0.0-dev"},
+		{"tilde ~1.2.2-stable", "~1.2.2-stable", ">= 1.2.2.0", "< 1.3.0.0-dev"},
+		{"tilde ~201903.0", "~201903.0", ">= 201903.0-dev", "< 201904.0.0.0-dev"},
+		{"tilde ~201903.0-beta", "~201903.0-beta", ">= 201903.0-beta", "< 201904.0.0.0-dev"},
+		{"tilde ~201903.0-stable", "~201903.0-stable", ">= 201903.0", "< 201904.0.0.0-dev"},
+		{"tilde ~201903.205830.1-stable", "~201903.205830.1-stable", ">= 201903.205830.1", "< 201903.205831.0.0-dev"},
+		{"tilde ~2.x-dev", "~2.x-dev", ">= 2.9999999.9999999.9999999-dev", "< 3.0.0.0-dev"},
+		{"tilde ~2.0.x-dev", "~2.0.x-dev", ">= 2.0.9999999.9999999-dev", "< 2.1.0.0-dev"},
+		{"tilde ~2.0.3.x-dev", "~2.0.3.x-dev", ">= 2.0.3.9999999-dev", "< 2.0.4.0-dev"},
+		{"tilde ~0.x-dev", "~0.x-dev", ">= 0.9999999.9999999.9999999-dev", "< 1.0.0.0-dev"},
+		{"caret ^v1", "^v1", ">= 1.0.0.0-dev", "< 2.0.0.0-dev"},
+		{"caret ^0", "^0", ">= 0.0.0.0-dev", "< 1.0.0.0-dev"},
+		{"caret ^0.0", "^0.0", ">= 0.0.0.0-dev", "< 0.1.0.0-dev"},
+		{"caret ^1.2", "^1.2", ">= 1.2.0.0-dev", "< 2.0.0.0-dev"},
+		{"caret ^1.2.3-beta.2", "^1.2.3-beta.2", ">= 1.2.3.0-beta2", "< 2.0.0.0-dev"},
+		{"caret ^1.2.3.4", "^1.2.3.4", ">= 1.2.3.4-dev", "< 2.0.0.0-dev"},
+		{"caret ^1.2.3", "^1.2.3", ">= 1.2.3.0-dev", "< 2.0.0.0-dev"},
+		{"caret ^0.2.3", "^0.2.3", ">= 0.2.3.0-dev", "< 0.3.0.0-dev"},
+		{"caret ^0.2", "^0.2", ">= 0.2.0.0-dev", "< 0.3.0.0-dev"},
+		{"caret ^0.2.0", "^0.2.0", ">= 0.2.0.0-dev", "< 0.3.0.0-dev"},
+		{"caret ^0.0.3", "^0.0.3", ">= 0.0.3.0-dev", "< 0.0.4.0-dev"},
+		{"caret ^0.0.3-alpha", "^0.0.3-alpha", ">= 0.0.3.0-alpha", "< 0.0.4.0-dev"},
+		{"caret ^0.0.3-dev", "^0.0.3-dev", ">= 0.0.3.0-dev", "< 0.0.4.0-dev"},
+		{"caret ^0.0.3-stable", "^0.0.3-stable", ">= 0.0.3.0", "< 0.0.4.0-dev"},
+		{"caret ^201903.0", "^201903.0", ">= 201903.0-dev", "< 201904.0.0.0-dev"},
+		{"caret ^201903.0-beta", "^201903.0-beta", ">= 201903.0-beta", "< 201904.0.0.0-dev"},
+		{"caret ^201903.205830.1-stable", "^201903.205830.1-stable", ">= 201903.205830.1", "< 201904.0.0.0-dev"},
+		{"caret ^2.x-dev", "^2.x-dev", ">= 2.9999999.9999999.9999999-dev", "< 3.0.0.0-dev"},
+		{"caret ^2.0.*-dev", "^2.0.*-dev", ">= 2.0.9999999.9999999-dev", "< 3.0.0.0-dev"},
+		{"caret ^2.0.x-dev", "^2.0.x-dev", ">= 2.0.9999999.9999999-dev", "< 3.0.0.0-dev"},
+		{"caret ^2.0.3.x-dev", "^2.0.3.x-dev", ">= 2.0.3.9999999-dev", "< 3.0.0.0-dev"},
+		{"caret ^0.x-dev", "^0.x-dev", ">= 0.9999999.9999999.9999999-dev", "< 1.0.0.0-dev"},
+		{"hyphen v1 - v2", "v1 - v2", ">= 1.0.0.0-dev", "< 3.0.0.0-dev"},
+		{"hyphen 1.2.3 - 2.3.4.5", "1.2.3 - 2.3.4.5", ">= 1.2.3.0-dev", "<= 2.3.4.5"},
+		{"hyphen 1.2-beta - 2.3", "1.2-beta - 2.3", ">= 1.2.0.0-beta", "< 2.4.0.0-dev"},
+		{"hyphen 1.2-beta - 2.3-dev", "1.2-beta - 2.3-dev", ">= 1.2.0.0-beta", "<= 2.3.0.0-dev"},
+		{"hyphen 1.2-RC - 2.3.1", "1.2-RC - 2.3.1", ">= 1.2.0.0-RC", "<= 2.3.1.0"},
+		{"hyphen 1.2.3-alpha - 2.3-RC", "1.2.3-alpha - 2.3-RC", ">= 1.2.3.0-alpha", "<= 2.3.0.0-RC"},
+		{"hyphen 1 - 2.0", "1 - 2.0", ">= 1.0.0.0-dev", "< 2.1.0.0-dev"},
+		{"hyphen 1 - 2.1", "1 - 2.1", ">= 1.0.0.0-dev", "< 2.2.0.0-dev"},
+		{"hyphen 1.2 - 2.1.0", "1.2 - 2.1.0", ">= 1.2.0.0-dev", "<= 2.1.0.0"},
+		{"hyphen 1.3 - 2.1.3", "1.3 - 2.1.3", ">= 1.3.0.0-dev", "<= 2.1.3.0"},
+		{"hyphen 2.0.3.x-dev - 3.0.3.x-dev", "2.0.3.x-dev - 3.0.3.x-dev", ">= 2.0.3.9999999-dev", "<= 3.0.3.9999999-dev"},
+		{"hyphen 2.0.x-dev - 3.0.x-dev", "2.0.x-dev - 3.0.x-dev", ">= 2.0.9999999.9999999-dev", "<= 3.0.9999999.9999999-dev"},
+		{"hyphen 2.x-dev - 3.x-dev", "2.x-dev - 3.x-dev", ">= 2.9999999.9999999.9999999-dev", "<= 3.9999999.9999999.9999999-dev"},
+		{"hyphen 0.x-dev - 1.x-dev", "0.x-dev - 1.x-dev", ">= 0.9999999.9999999.9999999-dev", "<= 1.9999999.9999999.9999999-dev"},
+	}
+
+	for _, tc := range tests {
+		domains, err := constraintUnionDomains(tc.constraint)
+		if err != nil {
+			t.Errorf("%s: constraintUnionDomains(%q) unexpected error: %v", tc.name, tc.constraint, err)
+			continue
+		}
+		expected := domainSnapshot{
+			Numeric:  []intervalSnapshot{{Start: tc.start, End: tc.end}},
+			Branches: noDev,
+		}
+		if actual := domainUnionSnapshot(domains); !reflect.DeepEqual(actual, expected) {
+			t.Errorf("%s: expected %#v, got %#v", tc.name, expected, actual)
+		}
+	}
+}
+
+func TestVersionParserParseConstraintBehavior(t *testing.T) {
+	satisfies := []struct {
+		version    string
+		constraint string
+		expected   bool
+	}{
+		{"1.0.0", "1.0@dev", true},
+		{"1.0.0-beta", ">=1.0@beta", true},
+		{"1.0.0-alpha", ">=1.0@beta", false},
+		{"dev-load-varnish-only-when-used", "dev-load-varnish-only-when-used as ^2.0@dev", true},
+		{"dev-load-varnish-only-when-used", "dev-load-varnish-only-when-used@dev as ^2.0@dev", true},
+		{"1.0.9999999.9999999-dev", "1.0.x-dev#abcd123", true},
+		{"1.0.9999999.9999999-dev", "1.0.x-dev#trunk/@123", true},
+		{"2.5", "~2.5.9|~2.6,>=2.6.2", false},
+		{"2.5.9", "~2.5.9|~2.6,>=2.6.2", true},
+		{"2.6.1", "~2.5.9|~2.6,>=2.6.2", false},
+		{"2.6.2", "~2.5.9|~2.6,>=2.6.2", true},
+		{"2.0.1", ">2.0,<=3.0", true},
+		{"2.0.1", ">2.0  <=3.0", true},
+		{"2.0.1", ">2.0, <=3.0", true},
+		{"2.0.1", ">2.0 ,<=3.0", true},
+		{"2.0.1", ">2.0 , <=3.0", true},
+		{"2.0.1", ">2.0   , <=3.0", true},
+		{"2.0.1", "> 2.0  ,  <=  3.0", true},
+		{"2.0.1", "  > 2.0  ,  <=  3.0 ", true},
+		{"3.0", ">2.0 <=3.0", true},
+		{"2.0", "> 2.0   <=  3.0", false},
+		{"2.0.4", ">2.0,<2.0.5 | >2.0.6", true},
+		{"2.0.5", ">2.0,<2.0.5 | >2.0.6", false},
+		{"2.0.7", ">2.0,<2.0.5 | >2.0.6", true},
+		{"2.0.4", ">2.0,<2.0.5 || >2.0.6", true},
+		{"2.0.5", ">2.0,<2.0.5 || >2.0.6", false},
+		{"2.0.7", ">2.0,<2.0.5 || >2.0.6", true},
+		{"2.0.4", "> 2.0 , <2.0.5 | >  2.0.6", true},
+		{"2.0.5", "> 2.0 , <2.0.5 | >  2.0.6", false},
+		{"2.0.7", "> 2.0 , <2.0.5 | >  2.0.6", true},
+		{"1.1.0-alpha4", ">=1.1.0-alpha4,<1.2.x-dev", true},
+		{"1.2.9999999.9999999-dev", ">=1.1.0-alpha4,<1.2.x-dev", false},
+		{"1.2.0-beta1", ">=1.1.0-alpha4,<1.2-beta2", true},
+		{"1.2.0-beta2", ">=1.1.0-alpha4,<1.2-beta2", false},
+		{"3.0-dev", ">2.0@stable,<=3.0@dev", true},
+		{"3.0", ">2.0@stable,<=3.0@dev", false},
+		{"2.1", ">2.0@stable,@dev", true},
+		{"2.0", ">2.0@stable,@dev", false},
+		{"0", ">2.0@stable || 0@dev", true},
+		{"2.1", ">2.0@stable || 0@dev", true},
+		{"1.0", ">2.0@stable || 0@dev", false},
+		{"1.0.1", "~0.1 || ~1.0 !=1.0.1", false},
+		{"1.0.2", "~0.1 || ~1.0 !=1.0.1", true},
+	}
+
+	for _, tc := range satisfies {
+		actual, err := checkSatisfiesForTest(tc.version, tc.constraint)
+		if err != nil {
+			t.Errorf("Satisfies(%q, %q) unexpected error: %v", tc.version, tc.constraint, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("Satisfies(%q, %q): expected %v, got %v", tc.version, tc.constraint, tc.expected, actual)
+		}
+	}
+
+	invalid := []string{
+		"1.0#abcd123",
+		"1.0#trunk/@123",
+	}
+	for _, constraint := range invalid {
+		if _, err := NewConstraint(constraint); err == nil {
+			t.Errorf("expected constraint %q to be rejected", constraint)
+		}
+	}
+}
+
+func TestVersionParserMultiConstraintSnapshots(t *testing.T) {
+	noDev := branchSnapshot{Names: []string{}}
+	conjunctive := []string{
+		">2.0,<=3.0",
+		">2.0 <=3.0",
+		">2.0  <=3.0",
+		">2.0, <=3.0",
+		">2.0 ,<=3.0",
+		">2.0 , <=3.0",
+		">2.0   , <=3.0",
+		"> 2.0   <=  3.0",
+		"> 2.0  ,  <=  3.0",
+		"  > 2.0  ,  <=  3.0 ",
+	}
+
+	for _, constraint := range conjunctive {
+		domains, err := constraintUnionDomains(constraint)
+		if err != nil {
+			t.Errorf("constraintUnionDomains(%q) unexpected error: %v", constraint, err)
+			continue
+		}
+		expected := domainSnapshot{
+			Numeric:  []intervalSnapshot{{Start: "> 2.0.0.0", End: "<= 3.0.0.0"}},
+			Branches: noDev,
+		}
+		if actual := domainUnionSnapshot(domains); !reflect.DeepEqual(actual, expected) {
+			t.Errorf("constraintUnionDomains(%q): expected %#v, got %#v", constraint, expected, actual)
+		}
+	}
+
+	disjunctive := []string{
+		">2.0,<2.0.5 | >2.0.6",
+		">2.0,<2.0.5 || >2.0.6",
+		"> 2.0 , <2.0.5 | >  2.0.6",
+	}
+
+	for _, constraint := range disjunctive {
+		domains, err := constraintUnionDomains(constraint)
+		if err != nil {
+			t.Errorf("constraintUnionDomains(%q) unexpected error: %v", constraint, err)
+			continue
+		}
+		expected := domainSnapshot{
+			Numeric: []intervalSnapshot{
+				{Start: "> 2.0.0.0", End: "< 2.0.5.0-dev"},
+				{Start: "> 2.0.6.0", End: "< +Inf"},
+			},
+			Branches: noDev,
+		}
+		if actual := domainUnionSnapshot(domains); !reflect.DeepEqual(actual, expected) {
+			t.Errorf("constraintUnionDomains(%q): expected %#v, got %#v", constraint, expected, actual)
+		}
+	}
+
+	stability := []struct {
+		constraint string
+		expected   domainSnapshot
+	}{
+		{
+			constraint: ">=1.1.0-alpha4,<1.2.x-dev",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 1.1.0.0-alpha4", End: "< 1.2.9999999.9999999-dev"}},
+				Branches: noDev,
+			},
+		},
+		{
+			constraint: ">=1.1.0-alpha4,<1.2-beta2",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 1.1.0.0-alpha4", End: "< 1.2.0.0-beta2"}},
+				Branches: noDev,
+			},
+		},
+		{
+			constraint: ">2.0@stable,<=3.0@dev",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: "> 2.0.0.0", End: "<= 3.0.0.0-dev"}},
+				Branches: noDev,
+			},
+		},
+		{
+			constraint: ">2.0@stable,@dev",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: "> 2.0.0.0", End: "< +Inf"}},
+				Branches: noDev,
+			},
+		},
+		{
+			constraint: ">2.0@stable || 0@dev",
+			expected: domainSnapshot{
+				Numeric: []intervalSnapshot{
+					{Start: ">= 0.0.0.0", End: "<= 0.0.0.0"},
+					{Start: "> 2.0.0.0", End: "< +Inf"},
+				},
+				Branches: noDev,
+			},
+		},
+	}
+
+	for _, tc := range stability {
+		domains, err := constraintUnionDomains(tc.constraint)
+		if err != nil {
+			t.Errorf("constraintUnionDomains(%q) unexpected error: %v", tc.constraint, err)
+			continue
+		}
+		if actual := domainUnionSnapshot(domains); !reflect.DeepEqual(actual, tc.expected) {
+			t.Errorf("constraintUnionDomains(%q): expected %#v, got %#v", tc.constraint, tc.expected, actual)
+		}
+	}
+}
+
+func TestVersionParserSimpleConstraintSnapshots(t *testing.T) {
+	noDev := branchSnapshot{Names: []string{}}
+	allBranches := branchSnapshot{Names: []string{}, Exclude: true}
+	allNumeric := []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}}
+	exact := func(version string) []intervalSnapshot {
+		return []intervalSnapshot{{Start: ">= " + version, End: "<= " + version}}
+	}
+
+	tests := []struct {
+		name       string
+		constraint string
+		expected   domainSnapshot
+	}{
+		{"match any", "*", domainSnapshot{Numeric: allNumeric, Branches: allBranches}},
+		{"match any/v", "v*", domainSnapshot{Numeric: allNumeric, Branches: noDev}},
+		{"match any/2", "*.*", domainSnapshot{Numeric: allNumeric, Branches: noDev}},
+		{"match any/2v", "v*.*", domainSnapshot{Numeric: allNumeric, Branches: noDev}},
+		{"match any/3", "*.x.*", domainSnapshot{Numeric: allNumeric, Branches: noDev}},
+		{"match any/4", "x.X.x.*", domainSnapshot{Numeric: allNumeric, Branches: noDev}},
+		{
+			name:       "not equal",
+			constraint: "<>1.0.0",
+			expected: domainSnapshot{
+				Numeric: []intervalSnapshot{
+					{Start: ">= 0.0.0.0-dev", End: "< 1.0.0.0"},
+					{Start: "> 1.0.0.0", End: "< +Inf"},
+				},
+				Branches: allBranches,
+			},
+		},
+		{
+			name:       "not equal/2",
+			constraint: "!=1.0.0",
+			expected: domainSnapshot{
+				Numeric: []intervalSnapshot{
+					{Start: ">= 0.0.0.0-dev", End: "< 1.0.0.0"},
+					{Start: "> 1.0.0.0", End: "< +Inf"},
+				},
+				Branches: allBranches,
+			},
+		},
+		{"greater than", ">1.0.0", domainSnapshot{Numeric: []intervalSnapshot{{Start: "> 1.0.0.0", End: "< +Inf"}}, Branches: noDev}},
+		{"lesser than", "<1.2.3.4", domainSnapshot{Numeric: []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< 1.2.3.4-dev"}}, Branches: noDev}},
+		{"less/eq than", "<=1.2.3", domainSnapshot{Numeric: []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "<= 1.2.3.0"}}, Branches: noDev}},
+		{"great/eq than", ">=1.2.3", domainSnapshot{Numeric: []intervalSnapshot{{Start: ">= 1.2.3.0-dev", End: "< +Inf"}}, Branches: noDev}},
+		{"equals", "=1.2.3", domainSnapshot{Numeric: exact("1.2.3.0"), Branches: noDev}},
+		{"double equals", "==1.2.3", domainSnapshot{Numeric: exact("1.2.3.0"), Branches: noDev}},
+		{"no op means eq", "1.2.3", domainSnapshot{Numeric: exact("1.2.3.0"), Branches: noDev}},
+		{"completes version", "=1.0", domainSnapshot{Numeric: exact("1.0.0.0"), Branches: noDev}},
+		{"shorthand beta", "1.2.3b5", domainSnapshot{Numeric: exact("1.2.3.0-beta5"), Branches: noDev}},
+		{"shorthand alpha", "1.2.3a1", domainSnapshot{Numeric: exact("1.2.3.0-alpha1"), Branches: noDev}},
+		{"shorthand patch", "1.2.3p1234", domainSnapshot{Numeric: exact("1.2.3.0-patch1234"), Branches: noDev}},
+		{"shorthand patch/2", "1.2.3pl1234", domainSnapshot{Numeric: exact("1.2.3.0-patch1234"), Branches: noDev}},
+		{"accepts spaces", ">= 1.2.3", domainSnapshot{Numeric: []intervalSnapshot{{Start: ">= 1.2.3.0-dev", End: "< +Inf"}}, Branches: noDev}},
+		{"accepts spaces/2", "< 1.2.3", domainSnapshot{Numeric: []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< 1.2.3.0-dev"}}, Branches: noDev}},
+		{"accepts spaces/3", "> 1.2.3", domainSnapshot{Numeric: []intervalSnapshot{{Start: "> 1.2.3.0", End: "< +Inf"}}, Branches: noDev}},
+		{"accepts master", ">=dev-master", domainSnapshot{Branches: noDev}},
+		{"accepts master/2", "dev-master", domainSnapshot{Branches: branchSnapshot{Names: []string{"dev-master"}}}},
+		{"accepts arbitrary", "dev-feature-a", domainSnapshot{Branches: branchSnapshot{Names: []string{"dev-feature-a"}}}},
+		{"regression #550", "dev-some-fix", domainSnapshot{Branches: branchSnapshot{Names: []string{"dev-some-fix"}}}},
+		{"regression #935", "dev-CAPS", domainSnapshot{Branches: branchSnapshot{Names: []string{"dev-CAPS"}}}},
+		{"ignores aliases", "dev-master as 1.0.0", domainSnapshot{Branches: branchSnapshot{Names: []string{"dev-master"}}}},
+		{"lesser than override", "<1.2.3.4-stable", domainSnapshot{Numeric: []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< 1.2.3.4"}}, Branches: noDev}},
+		{"great/eq than override", ">=1.2.3.4-stable", domainSnapshot{Numeric: []intervalSnapshot{{Start: ">= 1.2.3.4", End: "< +Inf"}}, Branches: noDev}},
+	}
+
+	for _, tc := range tests {
+		domains, err := constraintUnionDomains(tc.constraint)
+		if err != nil {
+			t.Errorf("%s: constraintUnionDomains(%q) unexpected error: %v", tc.name, tc.constraint, err)
+			continue
+		}
+		actual := domainUnionSnapshot(domains)
+		if !reflect.DeepEqual(actual, tc.expected) {
+			t.Errorf("%s: expected %#v, got %#v", tc.name, tc.expected, actual)
+		}
+	}
+}
+
+func TestVersionParserConstraintSnapshots(t *testing.T) {
+	noDev := branchSnapshot{Names: []string{}}
+	exact := func(version string) []intervalSnapshot {
+		return []intervalSnapshot{{Start: ">= " + version, End: "<= " + version}}
+	}
+	branchOnly := func(name string) domainSnapshot {
+		return domainSnapshot{Branches: branchSnapshot{Names: []string{name}}}
+	}
+
+	tests := []struct {
+		name       string
+		constraint string
+		expected   domainSnapshot
+	}{
+		{"numeric branch", "3.x-dev", domainSnapshot{Numeric: exact("3.9999999.9999999.9999999-dev"), Branches: noDev}},
+		{"numeric branch without wildcard", "3-dev", domainSnapshot{Numeric: exact("3.0.0.0-dev"), Branches: noDev}},
+		{"non-numeric branch", "dev-3.x", branchOnly("dev-3.x")},
+		{"non-numeric branch suffix", "xsd2go-dev", branchOnly("dev-xsd2go")},
+		{"non-numeric dotted branch suffix", "3.next-dev", branchOnly("dev-3.next")},
+		{"non-numeric branch suffix/2", "foobar-dev", branchOnly("dev-foobar")},
+		{"non-numeric dev branch", "dev-xsd2go", branchOnly("dev-xsd2go")},
+		{"non-numeric dev branch/2", "dev-3.next", branchOnly("dev-3.next")},
+		{"non-numeric dev branch/3", "dev-foobar", branchOnly("dev-foobar")},
+		{"dev branch with constraint-like name", "dev-1.0.0-dev<1.0.5-dev", branchOnly("dev-1.0.0-dev<1.0.5-dev")},
+		{"dev branch with constraint-like name/2", "dev-1.0.0-dev<1.0.5", branchOnly("dev-1.0.0-dev<1.0.5")},
+		{"alias stripped", "foobar-dev as 2.1.0", branchOnly("dev-foobar")},
+		{"alias stripped in disjunction", "foobar-dev as 2.1.0 || 3.5", domainSnapshot{Numeric: exact("3.5.0.0"), Branches: branchSnapshot{Names: []string{"dev-foobar"}}}},
+		{"alias stripped in repeated disjunction", "foobar-dev as 2.1.0 || 3.5 as 1.5", domainSnapshot{Numeric: exact("3.5.0.0"), Branches: branchSnapshot{Names: []string{"dev-foobar"}}}},
+		{"hyphen dev upper", "2.1.0 - 2.3-dev", domainSnapshot{Numeric: []intervalSnapshot{{Start: ">= 2.1.0.0-dev", End: "<= 2.3.0.0-dev"}}, Branches: noDev}},
+		{"hyphen numeric dev upper wildcard", "1.0 - 2.0.x-dev", domainSnapshot{Numeric: []intervalSnapshot{{Start: ">= 1.0.0.0-dev", End: "<= 2.0.9999999.9999999-dev"}}, Branches: noDev}},
+		{"caret with trailing dot", "^1.", domainSnapshot{Numeric: []intervalSnapshot{{Start: ">= 1.0.0.0-dev", End: "< 2.0.0.0-dev"}}, Branches: noDev}},
+		{"tilde with trailing dot", "~1.", domainSnapshot{Numeric: []intervalSnapshot{{Start: ">= 1.0.0.0-dev", End: "< 2.0.0.0-dev"}}, Branches: noDev}},
+		{"version with trailing dot", "1.2.", domainSnapshot{Numeric: exact("1.2.0.0"), Branches: noDev}},
+		{"version with repeated dot dev", "1.2..dev", domainSnapshot{Numeric: exact("1.2.0.0-dev"), Branches: noDev}},
+		{"version with dash dot dev", "1.2-.dev", domainSnapshot{Numeric: exact("1.2.0.0-dev"), Branches: noDev}},
+		{"version with underscore dev", "1.2_-dev", domainSnapshot{Numeric: exact("1.2.0.0-dev"), Branches: noDev}},
+	}
+
+	for _, tc := range tests {
+		domains, err := constraintUnionDomains(tc.constraint)
+		if err != nil {
+			t.Errorf("%s: constraintUnionDomains(%q) unexpected error: %v", tc.name, tc.constraint, err)
+			continue
+		}
+		actual := domainUnionSnapshot(domains)
+		if !reflect.DeepEqual(actual, tc.expected) {
+			t.Errorf("%s: expected %#v, got %#v", tc.name, tc.expected, actual)
+		}
+	}
+}
+
+func TestConstraintVersionMatchesCases(t *testing.T) {
+	tests := []struct {
+		requireOp      string
+		requireVersion string
+		provideOp      string
+		provideVersion string
+		expected       bool
+	}{
+		{"==", "2", "==", "2", true},
+		{"==", "2", "<", "3", true},
+		{"==", "2", "<=", "2", true},
+		{"==", "2", "<=", "3", true},
+		{"==", "2", ">=", "1", true},
+		{"==", "2", ">=", "2", true},
+		{"==", "2", ">", "1", true},
+		{"==", "2", "!=", "1", true},
+		{"==", "2", "!=", "3", true},
+		{"<", "2", "==", "1", true},
+		{"<", "2", "<", "1", true},
+		{"<", "2", "<", "2", true},
+		{"<", "2", "<", "3", true},
+		{"<", "2", "<=", "1", true},
+		{"<", "2", "<=", "2", true},
+		{"<", "2", "<=", "3", true},
+		{"<", "2", ">=", "1", true},
+		{"<", "2", ">", "1", true},
+		{"<", "2", "!=", "1", true},
+		{"<", "2", "!=", "2", true},
+		{"<", "2", "!=", "3", true},
+		{"<=", "2", "==", "1", true},
+		{"<=", "2", "==", "2", true},
+		{"<=", "2", "<", "1", true},
+		{"<=", "2", "<", "2", true},
+		{"<=", "2", "<", "3", true},
+		{"<=", "2", "<=", "1", true},
+		{"<=", "2", "<=", "2", true},
+		{"<=", "2", "<=", "3", true},
+		{"<=", "2", ">=", "1", true},
+		{"<=", "2", ">=", "2", true},
+		{"<=", "2", ">", "1", true},
+		{"<=", "2", "!=", "1", true},
+		{"<=", "2", "!=", "2", true},
+		{"<=", "2", "!=", "3", true},
+		{">=", "2", "==", "2", true},
+		{">=", "2", "==", "3", true},
+		{">=", "2", "<", "3", true},
+		{">=", "2", "<=", "2", true},
+		{">=", "2", "<=", "3", true},
+		{">=", "2", ">=", "1", true},
+		{">=", "2", ">=", "2", true},
+		{">=", "2", ">=", "3", true},
+		{">=", "2", ">", "1", true},
+		{">=", "2", ">", "2", true},
+		{">=", "2", ">", "3", true},
+		{">=", "2", "!=", "1", true},
+		{">=", "2", "!=", "2", true},
+		{">=", "2", "!=", "3", true},
+		{">", "2", "==", "3", true},
+		{">", "2", "<", "3", true},
+		{">", "2", "<=", "3", true},
+		{">", "2", ">=", "1", true},
+		{">", "2", ">=", "2", true},
+		{">", "2", ">=", "3", true},
+		{">", "2", ">", "1", true},
+		{">", "2", ">", "2", true},
+		{">", "2", ">", "3", true},
+		{">", "2", "!=", "1", true},
+		{">", "2", "!=", "2", true},
+		{">", "2", "!=", "3", true},
+		{"!=", "2", "!=", "1", true},
+		{"!=", "2", "!=", "2", true},
+		{"!=", "2", "!=", "3", true},
+		{"!=", "2", "==", "1", true},
+		{"!=", "2", "==", "3", true},
+		{"!=", "2", "<", "1", true},
+		{"!=", "2", "<", "2", true},
+		{"!=", "2", "<", "3", true},
+		{"!=", "2", "<=", "1", true},
+		{"!=", "2", "<=", "2", true},
+		{"!=", "2", "<=", "3", true},
+		{"!=", "2", ">=", "1", true},
+		{"!=", "2", ">=", "2", true},
+		{"!=", "2", ">=", "3", true},
+		{"!=", "2", ">", "1", true},
+		{"!=", "2", ">", "2", true},
+		{"!=", "2", ">", "3", true},
+		{"==", "dev-foo-bar", "==", "dev-foo-bar", true},
+		{"==", "dev-events+issue-17", "==", "dev-events+issue-17", true},
+		{"==", "dev-foo-bar", "!=", "dev-foo-xyz", true},
+		{"!=", "dev-foo-bar", "!=", "dev-foo-xyz", true},
+		{"==", "0.12", "!=", "dev-foo", true},
+		{"<", "0.12", "!=", "dev-foo", true},
+		{"<=", "0.12", "!=", "dev-foo", true},
+		{">=", "0.12", "!=", "dev-foo", true},
+		{">", "0.12", "!=", "dev-foo", true},
+		{"!=", "0.12", "==", "dev-foo", true},
+		{"!=", "0.12", "!=", "dev-foo", true},
+		{"==", "2", "==", "1", false},
+		{"==", "2", "==", "3", false},
+		{"==", "2", "<", "1", false},
+		{"==", "2", "<", "2", false},
+		{"==", "2", "<=", "1", false},
+		{"==", "2", ">=", "3", false},
+		{"==", "2", ">", "2", false},
+		{"==", "2", ">", "3", false},
+		{"==", "2", "!=", "2", false},
+		{"<", "2", "==", "2", false},
+		{"<", "2", "==", "3", false},
+		{"<", "2", ">=", "2", false},
+		{"<", "2", ">=", "3", false},
+		{"<", "2", ">", "2", false},
+		{"<", "2", ">", "3", false},
+		{"<=", "2", "==", "3", false},
+		{"<=", "2", ">=", "3", false},
+		{"<=", "2", ">", "2", false},
+		{"<=", "2", ">", "3", false},
+		{">=", "2", "==", "1", false},
+		{">=", "2", "<", "1", false},
+		{">=", "2", "<", "2", false},
+		{">=", "2", "<=", "1", false},
+		{">", "2", "==", "1", false},
+		{">", "2", "==", "2", false},
+		{">", "2", "<", "1", false},
+		{">", "2", "<", "2", false},
+		{">", "2", "<=", "1", false},
+		{">", "2", "<=", "2", false},
+		{"!=", "2", "==", "2", false},
+		{"==", "2.0-b2", "<", "2.0-beta2", false},
+		{"==", "dev-foo-dist", "==", "dev-foo-zist", false},
+		{"==", "dev-foo-bar", "==", "dev-foo-xyz", false},
+		{"==", "dev-foo-bar", "<", "dev-foo-xyz", false},
+		{"==", "dev-foo-bar", "<=", "dev-foo-xyz", false},
+		{"==", "dev-foo-bar", ">=", "dev-foo-xyz", false},
+		{"==", "dev-foo-bar", ">", "dev-foo-xyz", false},
+		{"<", "dev-foo-bar", "==", "dev-foo-xyz", false},
+		{"<", "dev-foo-bar", "<", "dev-foo-xyz", false},
+		{"<", "dev-foo-bar", "<=", "dev-foo-xyz", false},
+		{"<", "dev-foo-bar", ">=", "dev-foo-xyz", false},
+		{"<", "dev-foo-bar", ">", "dev-foo-xyz", false},
+		{"<", "dev-foo-bar", "!=", "dev-foo-xyz", false},
+		{"<=", "dev-foo-bar", "==", "dev-foo-xyz", false},
+		{"<=", "dev-foo-bar", "<", "dev-foo-xyz", false},
+		{"<=", "dev-foo-bar", "<=", "dev-foo-xyz", false},
+		{"<=", "dev-foo-bar", ">=", "dev-foo-xyz", false},
+		{"<=", "dev-foo-bar", ">", "dev-foo-xyz", false},
+		{"<=", "dev-foo-bar", "!=", "dev-foo-xyz", false},
+		{">=", "dev-foo-bar", "==", "dev-foo-xyz", false},
+		{">=", "dev-foo-bar", "<", "dev-foo-xyz", false},
+		{">=", "dev-foo-bar", "<=", "dev-foo-xyz", false},
+		{">=", "dev-foo-bar", ">=", "dev-foo-xyz", false},
+		{">=", "dev-foo-bar", ">", "dev-foo-xyz", false},
+		{">=", "dev-foo-bar", "!=", "dev-foo-xyz", false},
+		{">", "dev-foo-bar", "==", "dev-foo-xyz", false},
+		{">", "dev-foo-bar", "<", "dev-foo-xyz", false},
+		{">", "dev-foo-bar", "<=", "dev-foo-xyz", false},
+		{">", "dev-foo-bar", ">=", "dev-foo-xyz", false},
+		{">", "dev-foo-bar", ">", "dev-foo-xyz", false},
+		{">", "dev-foo-bar", "!=", "dev-foo-xyz", false},
+		{"==", "dev-foo-bar", "<", "dev-foo-bar", false},
+		{"==", "dev-foo-bar", "<=", "dev-foo-bar", false},
+		{"==", "dev-foo-bar", ">=", "dev-foo-bar", false},
+		{"==", "dev-foo-bar", ">", "dev-foo-bar", false},
+		{"==", "dev-foo-bar", "!=", "dev-foo-bar", false},
+		{"<", "dev-foo-bar", "==", "dev-foo-bar", false},
+		{"<", "dev-foo-bar", "<", "dev-foo-bar", false},
+		{"<", "dev-foo-bar", "<=", "dev-foo-bar", false},
+		{"<", "dev-foo-bar", ">=", "dev-foo-bar", false},
+		{"<", "dev-foo-bar", ">", "dev-foo-bar", false},
+		{"<", "dev-foo-bar", "!=", "dev-foo-bar", false},
+		{"<=", "dev-foo-bar", "==", "dev-foo-bar", false},
+		{"<=", "dev-foo-bar", "<", "dev-foo-bar", false},
+		{"<=", "dev-foo-bar", "<=", "dev-foo-bar", false},
+		{"<=", "dev-foo-bar", ">=", "dev-foo-bar", false},
+		{"<=", "dev-foo-bar", ">", "dev-foo-bar", false},
+		{"<=", "dev-foo-bar", "!=", "dev-foo-bar", false},
+		{">=", "dev-foo-bar", "==", "dev-foo-bar", false},
+		{">=", "dev-foo-bar", "<", "dev-foo-bar", false},
+		{">=", "dev-foo-bar", "<=", "dev-foo-bar", false},
+		{">=", "dev-foo-bar", ">=", "dev-foo-bar", false},
+		{">=", "dev-foo-bar", ">", "dev-foo-bar", false},
+		{">=", "dev-foo-bar", "!=", "dev-foo-bar", false},
+		{">", "dev-foo-bar", "==", "dev-foo-bar", false},
+		{">", "dev-foo-bar", "<", "dev-foo-bar", false},
+		{">", "dev-foo-bar", "<=", "dev-foo-bar", false},
+		{">", "dev-foo-bar", ">=", "dev-foo-bar", false},
+		{">", "dev-foo-bar", ">", "dev-foo-bar", false},
+		{">", "dev-foo-bar", "!=", "dev-foo-bar", false},
+		{"==", "0.12", "==", "dev-foo", false},
+		{"==", "0.12", "<", "dev-foo", false},
+		{"==", "0.12", "<=", "dev-foo", false},
+		{"==", "0.12", ">=", "dev-foo", false},
+		{"==", "0.12", ">", "dev-foo", false},
+		{"<", "0.12", "==", "dev-foo", false},
+		{"<", "0.12", "<", "dev-foo", false},
+		{"<", "0.12", "<=", "dev-foo", false},
+		{"<", "0.12", ">=", "dev-foo", false},
+		{"<", "0.12", ">", "dev-foo", false},
+		{"<=", "0.12", "==", "dev-foo", false},
+		{"<=", "0.12", "<", "dev-foo", false},
+		{"<=", "0.12", "<=", "dev-foo", false},
+		{"<=", "0.12", ">=", "dev-foo", false},
+		{"<=", "0.12", ">", "dev-foo", false},
+		{">=", "0.12", "==", "dev-foo", false},
+		{">=", "0.12", "<", "dev-foo", false},
+		{">=", "0.12", "<=", "dev-foo", false},
+		{">=", "0.12", ">=", "dev-foo", false},
+		{">=", "0.12", ">", "dev-foo", false},
+		{">", "0.12", "==", "dev-foo", false},
+		{">", "0.12", "<", "dev-foo", false},
+		{">", "0.12", "<=", "dev-foo", false},
+		{">", "0.12", ">=", "dev-foo", false},
+		{">", "0.12", ">", "dev-foo", false},
+		{"!=", "0.12", "<", "dev-foo", false},
+		{"!=", "0.12", "<=", "dev-foo", false},
+		{"!=", "0.12", ">=", "dev-foo", false},
+		{"!=", "0.12", ">", "dev-foo", false},
+	}
+
+	for _, tc := range tests {
+		left := tc.requireOp + " " + tc.requireVersion
+		right := tc.provideOp + " " + tc.provideVersion
+		actual, err := ConstraintIntersects(left, right)
+		if err != nil {
+			t.Errorf("ConstraintIntersects(%q, %q) unexpected error: %v", left, right, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("ConstraintIntersects(%q, %q): expected %v, got %v", left, right, tc.expected, actual)
+		}
+
+		actual, err = ConstraintIntersects(right, left)
+		if err != nil {
+			t.Errorf("ConstraintIntersects(%q, %q) unexpected error: %v", right, left, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("ConstraintIntersects(%q, %q): expected %v, got %v", right, left, tc.expected, actual)
+		}
+	}
+}
+
+func TestConstraintBoundsCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		operator string
+		version  string
+		lower    boundSnapshot
+		upper    boundSnapshot
+	}{
+		{"equal to 1.0.0.0", "==", "1.0.0.0", boundSnapshot{"1.0.0.0", true}, boundSnapshot{"1.0.0.0", true}},
+		{"equal to 1.0.0.0-rc3", "==", "1.0.0.0-rc3", boundSnapshot{"1.0.0.0-RC3", true}, boundSnapshot{"1.0.0.0-RC3", true}},
+		{"greater/equal dev feature branch", ">=", "dev-feature-branch", zeroBoundSnapshot(), positiveInfinityBoundSnapshot()},
+		{"lower than 0.0.4.0", "<", "0.0.4.0", zeroBoundSnapshot(), boundSnapshot{"0.0.4.0", false}},
+		{"lower than 1.0.0.0", "<", "1.0.0.0", zeroBoundSnapshot(), boundSnapshot{"1.0.0.0", false}},
+		{"lower than 2.0.0.0", "<", "2.0.0.0", zeroBoundSnapshot(), boundSnapshot{"2.0.0.0", false}},
+		{"lower than 3.0.3.0", "<", "3.0.3.0", zeroBoundSnapshot(), boundSnapshot{"3.0.3.0", false}},
+		{"lower than 3.0.3.0-rc3", "<", "3.0.3.0-rc3", zeroBoundSnapshot(), boundSnapshot{"3.0.3.0-RC3", false}},
+		{"lower than dev feature branch", "<", "dev-feature-branch", zeroBoundSnapshot(), positiveInfinityBoundSnapshot()},
+		{"greater than 0.0.4.0", ">", "0.0.4.0", boundSnapshot{"0.0.4.0", false}, positiveInfinityBoundSnapshot()},
+		{"greater than 1.0.0.0", ">", "1.0.0.0", boundSnapshot{"1.0.0.0", false}, positiveInfinityBoundSnapshot()},
+		{"greater than 2.0.0.0", ">", "2.0.0.0", boundSnapshot{"2.0.0.0", false}, positiveInfinityBoundSnapshot()},
+		{"greater than 3.0.3.0", ">", "3.0.3.0", boundSnapshot{"3.0.3.0", false}, positiveInfinityBoundSnapshot()},
+		{"greater than 3.0.3.0-rc3", ">", "3.0.3.0-rc3", boundSnapshot{"3.0.3.0-RC3", false}, positiveInfinityBoundSnapshot()},
+		{"greater than dev feature branch", ">", "dev-feature-branch", zeroBoundSnapshot(), positiveInfinityBoundSnapshot()},
+		{"lower/equal 0.0.4.0", "<=", "0.0.4.0", zeroBoundSnapshot(), boundSnapshot{"0.0.4.0", true}},
+		{"lower/equal 1.0.0.0", "<=", "1.0.0.0", zeroBoundSnapshot(), boundSnapshot{"1.0.0.0", true}},
+		{"lower/equal 2.0.0.0", "<=", "2.0.0.0", zeroBoundSnapshot(), boundSnapshot{"2.0.0.0", true}},
+		{"lower/equal 3.0.3.0", "<=", "3.0.3.0", zeroBoundSnapshot(), boundSnapshot{"3.0.3.0", true}},
+		{"lower/equal 3.0.3.0-rc3", "<=", "3.0.3.0-rc3", zeroBoundSnapshot(), boundSnapshot{"3.0.3.0-RC3", true}},
+		{"lower/equal dev feature branch", "<=", "dev-feature-branch", zeroBoundSnapshot(), positiveInfinityBoundSnapshot()},
+		{"greater/equal 0.0.4.0", ">=", "0.0.4.0", boundSnapshot{"0.0.4.0", true}, positiveInfinityBoundSnapshot()},
+		{"greater/equal 1.0.0.0", ">=", "1.0.0.0", boundSnapshot{"1.0.0.0", true}, positiveInfinityBoundSnapshot()},
+		{"greater/equal 2.0.0.0", ">=", "2.0.0.0", boundSnapshot{"2.0.0.0", true}, positiveInfinityBoundSnapshot()},
+		{"greater/equal 3.0.3.0", ">=", "3.0.3.0", boundSnapshot{"3.0.3.0", true}, positiveInfinityBoundSnapshot()},
+		{"greater/equal 3.0.3.0-rc3", ">=", "3.0.3.0-rc3", boundSnapshot{"3.0.3.0-RC3", true}, positiveInfinityBoundSnapshot()},
+		{"not equal to 1.0.0.0", "<>", "1.0.0.0", zeroBoundSnapshot(), positiveInfinityBoundSnapshot()},
+	}
+
+	for _, tc := range tests {
+		lower, upper, err := constraintBoundsSnapshot(tc.operator, tc.version)
+		if err != nil {
+			t.Errorf("%s: constraintBoundsSnapshot unexpected error: %v", tc.name, err)
+			continue
+		}
+		if lower != tc.lower || upper != tc.upper {
+			t.Errorf("%s: expected lower %#v upper %#v, got lower %#v upper %#v", tc.name, tc.lower, tc.upper, lower, upper)
+		}
+	}
+}
+
+func TestConstraintMatrixCases(t *testing.T) {
+	versions := []string{"1.0", "2.0", "dev-master", "dev-foo", "3.0-b2", "3.0-beta2"}
+	operators := []string{"==", "!=", ">", "<", ">=", "<="}
+
+	for _, requireVersion := range versions {
+		for _, requireOperator := range operators {
+			requireConstraint := requireOperator + " " + requireVersion
+			for _, provideVersion := range versions {
+				for _, provideOperator := range operators {
+					provideConstraint := provideOperator + " " + provideVersion
+					actual, err := ConstraintIntersects(requireConstraint, provideConstraint)
+					if err != nil {
+						t.Errorf("ConstraintIntersects(%q, %q) unexpected error: %v", requireConstraint, provideConstraint, err)
+						continue
+					}
+					reverse, err := ConstraintIntersects(provideConstraint, requireConstraint)
+					if err != nil {
+						t.Errorf("ConstraintIntersects(%q, %q) unexpected error: %v", provideConstraint, requireConstraint, err)
+						continue
+					}
+					if actual != reverse {
+						t.Errorf("ConstraintIntersects symmetry mismatch for %q and %q: %v vs %v", requireConstraint, provideConstraint, actual, reverse)
+					}
+
+					if provideOperator == "==" {
+						satisfied, err := checkSatisfiesForTest(provideVersion, requireConstraint)
+						if err != nil {
+							t.Errorf("Satisfies(%q, %q) unexpected error: %v", provideVersion, requireConstraint, err)
+							continue
+						}
+						if actual != satisfied {
+							t.Errorf("ConstraintIntersects(%q, %q): expected exact-version result %v, got %v", requireConstraint, provideConstraint, satisfied, actual)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestConstraintInvalidOperatorCases(t *testing.T) {
+	tests := []string{
+		"invalid 1.2.3",
+		"! 1.2.3",
+		"equals 1.2.3",
+	}
+
+	for _, constraint := range tests {
+		if _, err := NewConstraint(constraint); err == nil {
+			t.Errorf("expected invalid operator constraint %q to be rejected", constraint)
+		}
+	}
+}
+
+func TestConstraintComparableBranches(t *testing.T) {
+	tests := []struct {
+		version    string
+		constraint string
+		expected   bool
+	}{
+		{"dev-foo", ">0.12", false},
+		{"dev-foo", "<0.12", false},
+		{"dev-foo", ">=0.12", false},
+		{"dev-foo", "<=0.12", false},
+		{"dev-foo", "0.12", false},
+		{"dev-foo", "!=0.12", true},
+	}
+
+	for _, tc := range tests {
+		actual, err := checkSatisfiesForTest(tc.version, tc.constraint)
+		if err != nil {
+			t.Errorf("Satisfies(%q, %q) unexpected error: %v", tc.version, tc.constraint, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("Satisfies(%q, %q): expected %v, got %v", tc.version, tc.constraint, tc.expected, actual)
+		}
+	}
+
+	intersects, err := ConstraintIntersects(">0.12", "dev-foo")
+	if err != nil {
+		t.Fatalf("ConstraintIntersects unexpected error: %v", err)
+	}
+	if intersects {
+		t.Errorf("numeric range should not intersect exact dev branch")
+	}
+}
+
+func TestMultiConstraintBoundsCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		parts       []string
+		conjunctive bool
+		raw         bool
+		lower       boundSnapshot
+		upper       boundSnapshot
+	}{
+		{"all equal", []string{"1.0.0.0", "1.0.0.0"}, true, true, boundSnapshot{"1.0.0.0", true}, boundSnapshot{"1.0.0.0", true}},
+		{"greater should take precedence over greater/equal when conjunctive", []string{">1.0.0.0", ">=1.0.0.0", ">1.0.0.0"}, true, true, boundSnapshot{"1.0.0.0", false}, positiveInfinityBoundSnapshot()},
+		{"greater/equal should take precedence over greater when disjunctive", []string{">1.0.0.0", ">=1.0.0.0", ">1.0.0.0"}, false, true, boundSnapshot{"1.0.0.0", true}, positiveInfinityBoundSnapshot()},
+		{"bounds limited when conjunctive", []string{">=7.0.0.0", "<8.0.0.0"}, true, true, boundSnapshot{"7.0.0.0", true}, boundSnapshot{"8.0.0.0", false}},
+		{"bounds unlimited when disjunctive", []string{">=7.0.0.0", "<8.0.0.0"}, false, true, zeroBoundSnapshot(), positiveInfinityBoundSnapshot()},
+		{"integration ^7.0", []string{"^7.0"}, false, false, boundSnapshot{"7.0.0.0-dev", true}, boundSnapshot{"8.0.0.0-dev", false}},
+		{"integration ^7.2", []string{"^7.2"}, false, false, boundSnapshot{"7.2.0.0-dev", true}, boundSnapshot{"8.0.0.0-dev", false}},
+		{"integration 7.4 wildcard", []string{"7.4.*"}, false, false, boundSnapshot{"7.4.0.0-dev", true}, boundSnapshot{"7.5.0.0-dev", false}},
+		{"integration 7.2 or 7.4 wildcard", []string{"7.2.* || 7.4.*"}, false, false, boundSnapshot{"7.2.0.0-dev", true}, boundSnapshot{"7.5.0.0-dev", false}},
+		{"multiple multi constraints merging", []string{"^7.0", "^7.2", "7.4.*", "7.2.* || 7.4.*"}, true, false, boundSnapshot{"7.4.0.0-dev", true}, boundSnapshot{"7.5.0.0-dev", false}},
+		{"multiple multi constraints merging with gaps", []string{"^7.1.15 || ^7.2.3", "^7.2.2"}, true, false, boundSnapshot{"7.2.2.0-dev", true}, boundSnapshot{"8.0.0.0-dev", false}},
+	}
+
+	for _, tc := range tests {
+		var lower boundSnapshot
+		var upper boundSnapshot
+		var err error
+		if tc.raw {
+			lower, upper, err = combineRawConstraintBoundsSnapshot(tc.parts, tc.conjunctive)
+		} else {
+			var domains []constraintDomain
+			domains, err = composeConstraintDomains(tc.parts, tc.conjunctive)
+			if err == nil {
+				lower, upper = domainUnionBoundsSnapshot(domains)
+			}
+		}
+		if err != nil {
+			t.Errorf("%s: compose bounds unexpected error: %v", tc.name, err)
+			continue
+		}
+		if lower != tc.lower || upper != tc.upper {
+			t.Errorf("%s: expected lower %#v upper %#v, got lower %#v upper %#v", tc.name, tc.lower, tc.upper, lower, upper)
+		}
+	}
+}
+
+func TestSubsetsCases(t *testing.T) {
+	tests := []struct {
+		left     string
+		right    string
+		expected bool
+	}{
+		{"*", "*", true},
+		{"*", "!= 1 || == 1", true},
+		{"1.0.0", "*", true},
+		{"1.0.*", "*", true},
+		{"^1.0 || ^2.0", "*", true},
+		{"^3.0", "^3.2 || *", true},
+		{"^1.0 || ^2.0", "^1.0 || ^2.0", true},
+		{"^1.0 || ^2.0", "^1.0 || ^2.0 || ^4.0", true},
+		{"^1.0 || ^2.1", "^1.0 || ^2.1 || ^4.0", true},
+		{"^1.2", "^1.0 || ^2.0", true},
+		{"1.2.3", "^1.0 || ^2.0", true},
+		{"2.0.0-dev", "^1.0 || ^2.0", true},
+		{">= 2.1.0", ">= 2.0.0", true},
+		{"^2.0", "<3.0.0", true},
+		{"^3.0", "> 2.1.3", true},
+		{"3.0.0", "<= 3.0.0", true},
+		{"!= 3.0.0", "*", true},
+		{"!= 3.0.0", "!= 3.0", true},
+		{"!= 3.0, != 2.0", "!= 2.0, != 3.0", true},
+		{">3", "^2 || ^3 || >=4", true},
+		{">3", ">=3", true},
+		{"<3", "<=3", true},
+		{"= dev-foo", "= dev-foo", true},
+		{"!= dev-foo", "!= dev-foo", true},
+		{"< dev-foo", "= dev-foo", true},
+		{"1.5.*", "^1.4", true},
+		{"1.5.*", "1.3 - 1.6 || 1.8 - 1.9", true},
+		{"1.3.2", "1.3.0 || 1.3.1 || 1.3.2", true},
+		{"1.3.1", "1.3.0 || 1.3.1 || 1.3.2", true},
+		{"1.3.1 || 1.3.1", "1.3.1", true},
+		{"^1.0 || ^3.2", "^1.0 || ^3.0", true},
+		{"^1.3 || ^3.2", ">1.2", true},
+		{"^1.6", "<1.3 || >1.5", true},
+		{">1.6", "<1.3 || >1.5", true},
+		{">1.6", ">1.5, >1.4, !=1.1", true},
+		{">1.6", ">1.5 || >1.7", true},
+		{"^1.1", "> 1.0.0", true},
+		{"^1.1, !=1.5.0", "> 1.0.0", true},
+		{"^1.1, !=0.5.0", "> 1.0.0", true},
+		{"^2.0 || dev-foo", "> 1.0 || dev-foo || dev-bar", true},
+		{"^1.0, ^1.2", ">=1.2", true},
+		{"^1.0, ^1.2", "^1.2", true},
+		{"^1.0, ^1.2 || ^1.3", "^1.2", true},
+		{"*", ">= 1 || < 1", false},
+		{"*", "1.0.0", false},
+		{"*", "1.0.*", false},
+		{"*", "^1.0 || ^2.0", false},
+		{"^1.0 || ^2.0", "^1.0, ^2.0", false},
+		{"^1.0 || ^2.0", "^1.2", false},
+		{"^1.0 || ^2.0", "^1.0", false},
+		{"^1.0 || ^2.0", "1.2.3", false},
+		{"^1.0 || ^3.0", "1.2.3", false},
+		{"3.0.0", "^1.0 || ^2.0", false},
+		{"3.0.0", "< 3.0.0", false},
+		{"3.0.0", ">= 3.0.1", false},
+		{"!= 3.0.0", "> 3.0.0 || < 3.0.0-stable", false},
+		{"!= 3.0.0-dev", "^2.0 || <2 || >3.0-dev", false},
+		{"!= 3.0.0", "= 3.0.0", false},
+		{"!= 3.0.0", "!= 3.0.1", false},
+		{"!= 3.0.0", "dev-foo || dev-bar", false},
+		{"!= 3.0.0", "<dev-foo || >dev-bar", false},
+		{">= 1.0.0", "= 1.2.3", false},
+		{"< 2.0.0", "= 1.2.3", false},
+		{">3", "^2 || ^3 || >4", false},
+		{">=3", ">3", false},
+		{"<=3", "<3", false},
+		{"^2.1", "^2.0, !=2.1.3", false},
+		{"<2.0", ">=1.1", false},
+		{"!= dev-foo", "!= dev-bar", false},
+		{"!= dev-foo", "= dev-bar", false},
+		{"1.3.3", "1.3.0 || 1.3.1 || 1.3.2", false},
+		{"1.3.1 || 1.3.2", "1.3.1", false},
+		{">1.6", ">1.5, >1.4, !=1.7", false},
+		{">1.6", ">1.5, >1.7", false},
+		{"^1.0 || ^3.2", "^1.2 || ^3.0", false},
+		{"^1.0 || ^3.2", "^3.0", false},
+		{"^1.3 || ^3.2", ">1.4", false},
+		{"^2.0 || dev-foo", "> 1.0 || dev-bar", false},
+	}
+
+	for _, tc := range tests {
+		actual, err := ConstraintSubsetOf(tc.left, tc.right)
+		if err != nil {
+			t.Errorf("ConstraintSubsetOf(%q, %q) unexpected error: %v", tc.left, tc.right, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("ConstraintSubsetOf(%q, %q): expected %v, got %v", tc.left, tc.right, tc.expected, actual)
+		}
+	}
+}
+
+func TestIntervalsCompactCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		expected    string
+		toCompact   []string
+		conjunctive bool
+	}{
+		{"simple disjunctive multi", "1.0 - 1.2 || ^1.5", []string{"1.0 - 1.2 || ^1.5", "1.8 - 1.9 || ^1.12"}, false},
+		{"simple conjunctive multi", "1.8 - 1.9 || ^1.12", []string{"1.0 - 1.2 || ^1.5", "1.8 - 1.9 || ^1.12"}, true},
+		{"dev constraints propagate, disjunctive", "1.8 - 1.9 || ^1.12 || dev-master || dev-foo", []string{"1.8 - 1.9 || ^1.12", "dev-master", "dev-foo"}, false},
+		{"dev constraints + numeric constraint, conjunctive results in match-none", "", []string{"1.8 - 1.9 || ^1.12", "dev-master", "dev-foo"}, true},
+		{"conflicting numeric constraint, conjunctive results in match-none", "", []string{"1.0", "2.0"}, true},
+		{"simple disjunctive results in same output", "1.0 || 2.0", []string{"1.0", "2.0"}, false},
+		{"simple conjunctive results in same output", "!= 1.2, != 1.6", []string{"!= 1.2", "!= 1.6"}, true},
+		{"simple conjunctive results in same output/2", "!= 1.0, != 2.0", []string{"!= 1.0", "!= 2.0"}, true},
+		{"switches to conjunctive if more than != x is present", ">1.5, != 2.0", []string{"!= 2.0", "> 1.5"}, true},
+		{"complex conjunctive with dev", "!= 1.0, != 2.0", []string{"!= 1.0", "!= 2.0"}, true},
+		{"simple disjunctive with negation", "!= 1.0", []string{"!= 1.0", "!= 1.0"}, false},
+		{"disjunctive with complex negation", "*", []string{"!= 1.0", "!= 1.0", "!= dev-foo", "1.0.5.*"}, false},
+		{"conjunctive with complex negation", "1.0.5.*", []string{"!= 1.0", "!= 1.0", "!= dev-foo", "1.0.5.*"}, true},
+		{"conjunctive with complex negation/2", ">= 1.0-dev, != 1.2-stable, <2", []string{"!= 1.2", "!= dev-foo", "!= dev-bar", "1.*"}, true},
+		{"conjunctive with complex negation/3", "!= 1.2, != dev-foo, != dev-bar", []string{"!= 1.2", "!= dev-foo", "!= dev-bar"}, true},
+		{"disjunctive with complex negation/3", "*", []string{"!= 1.2", "!= dev-foo", "!= dev-bar"}, false},
+		{"conjunctive with complex negation/4", "== dev-foo", []string{"!= 1.2", "== dev-foo", "!= dev-bar"}, true},
+		{"disjunctive with complex negation and dev ==", "*", []string{"!= 1.0", "!= 1.0", "!= dev-foo", "1.0.5.*", "== dev-bla"}, false},
+		{"conjunctive with complex negation and dev ==", "dev-bla", []string{"!= 1.0", "!= 1.0", "!= dev-foo", "== dev-bla"}, true},
+		{"complex conjunctive which can not match anything", "", []string{"!= 1.0", "!= 1.0", "!= dev-foo", "1.0.5.*", "== dev-bla"}, true},
+		{"conjunctive with more than one dev negation", "!= dev-master, != dev-foo", []string{"!= dev-master", "!= dev-foo"}, true},
+		{"conjunctive with mix of devs", "== dev-foo", []string{"!= dev-master", "== dev-foo"}, true},
+		{"disjunctive with mix of devs", "!= dev-master", []string{"!= dev-master", "== dev-foo"}, false},
+		{"conjunctive with more than one dev negation, and numeric constraint", "> 5", []string{"!= dev-master", "!= dev-foo", "> 5"}, true},
+		{"conjunctive with more than one of the same dev negation", "!= dev-foo", []string{"!= dev-foo", "!= dev-foo"}, true},
+		{"switches to conjunctive when excluding versions and complex", "!= 3-stable, <5 || >=6, <9", []string{"!= 3, <5", ">=6, <9"}, false},
+		{"conjunctive with multiple numeric negations and a disjunctive exact match for dev versions", "== dev-foo || == dev-bar", []string{"!= 1.0", "!= 2.0", "==dev-foo || ==dev-bar"}, true},
+	}
+
+	for _, tc := range tests {
+		actual, err := composeConstraintDomains(tc.toCompact, tc.conjunctive)
+		if err != nil {
+			t.Errorf("%s: composeConstraintDomains unexpected error: %v", tc.name, err)
+			continue
+		}
+
+		if tc.expected == "" {
+			if !domainUnionEmpty(actual) {
+				t.Errorf("%s: expected composed constraints to match nothing", tc.name)
+			}
+			continue
+		}
+
+		expected, err := constraintUnionDomains(tc.expected)
+		if err != nil {
+			t.Errorf("%s: expected constraint %q unexpected error: %v", tc.name, tc.expected, err)
+			continue
+		}
+		if !domainUnionsEquivalent(actual, expected) {
+			t.Errorf("%s: composed constraints are not equivalent to %q", tc.name, tc.expected)
+		}
+	}
+}
+
+func TestIntervalsGetCases(t *testing.T) {
+	noDev := branchSnapshot{Names: []string{}}
+	tests := []struct {
+		name       string
+		constraint string
+		expected   domainSnapshot
+	}{
+		{
+			name:       "simple case",
+			constraint: "^1.0",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 1.0.0.0-dev", End: "< 2.0.0.0-dev"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "simple case/2",
+			constraint: "> 1.0",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: "> 1.0.0.0", End: "< +Inf"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "intervals should be sorted",
+			constraint: "1.3.4 || 1.2.3 || >2.3,<2.5 || <1,>=0.9",
+			expected: domainSnapshot{
+				Numeric: []intervalSnapshot{
+					{Start: ">= 0.9.0.0-dev", End: "< 1.0.0.0-dev"},
+					{Start: ">= 1.2.3.0", End: "<= 1.2.3.0"},
+					{Start: ">= 1.3.4.0", End: "<= 1.3.4.0"},
+					{Start: "> 2.3.0.0", End: "< 2.5.0.0-dev"},
+				},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "intervals should be sorted and consecutive ones merged",
+			constraint: "^4.0 || ^1.0 || ^3.0",
+			expected: domainSnapshot{
+				Numeric: []intervalSnapshot{
+					{Start: ">= 1.0.0.0-dev", End: "< 2.0.0.0-dev"},
+					{Start: ">= 3.0.0.0-dev", End: "< 5.0.0.0-dev"},
+				},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "consecutive intervals should be merged even if one has no end",
+			constraint: "^4.0 || >= 5",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 4.0.0.0-dev", End: "< +Inf"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "consecutive intervals should be merged even if one has no start",
+			constraint: ">= 5,< 6 || < 5",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< 6.0.0.0-dev"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "consecutive intervals representing everything should become any numeric",
+			constraint: ">= 5 || < 5",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "intervals should be sorted and overlapping ones merged",
+			constraint: "^4.0 || ^1.1 || ^3.0 || ^1.2",
+			expected: domainSnapshot{
+				Numeric: []intervalSnapshot{
+					{Start: ">= 1.1.0.0-dev", End: "< 2.0.0.0-dev"},
+					{Start: ">= 3.0.0.0-dev", End: "< 5.0.0.0-dev"},
+				},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "intervals should be sorted and overlapping ones merged/2",
+			constraint: "1.2 - 1.4 || 1.0 - 1.3",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 1.0.0.0-dev", End: "< 1.5.0.0-dev"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "overlapping intervals should be merged even if the last has no end",
+			constraint: "^4.0 || >= 4.5",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 4.0.0.0-dev", End: "< +Inf"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "overlapping intervals should be merged even if the first has no start",
+			constraint: ">= 5,< 6 || < 5.3",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< 6.0.0.0-dev"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "overlapping intervals representing everything should become any numeric",
+			constraint: ">= 5 || <= 5",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "equal intervals should be merged",
+			constraint: "^1.0 || ^1.0",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 1.0.0.0-dev", End: "< 2.0.0.0-dev"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "weird input order should still be a good result",
+			constraint: "< 2.0 || < 1.2",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< 2.0.0.0-dev"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "weird input order should still be a good result, matches everything numeric",
+			constraint: "< 2.0 || >= 1",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "weird input order should still be a good result, conjunctive",
+			constraint: "< 2.0, >= 1",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 1.0.0.0-dev", End: "< 2.0.0.0-dev"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "conjunctive constraints result in no interval if conflicting",
+			constraint: "^1.0, ^2.0",
+			expected:   domainSnapshot{Branches: noDev},
+		},
+		{
+			name:       "conjunctive constraints result in no interval if conflicting/2",
+			constraint: "^1.0, ^3.0",
+			expected:   domainSnapshot{Branches: noDev},
+		},
+		{
+			name:       "conjunctive constraints result in no interval if conflicting/3",
+			constraint: "== 1.0, != 1.0",
+			expected:   domainSnapshot{Branches: noDev},
+		},
+		{
+			name:       "conjunctive constraints result in no interval if conflicting/4",
+			constraint: "> 1.0, dev-master",
+			expected:   domainSnapshot{Branches: noDev},
+		},
+		{
+			name:       "conjunctive constraints result in no branches interval if numeric is provided",
+			constraint: "!= dev-master, != dev-foo, > 5",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: "> 5.0.0.0", End: "< +Inf"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "conjunctive constraints result in no branches interval if numeric is provided, even if one matches dev",
+			constraint: "!= 6, > 5",
+			expected: domainSnapshot{
+				Numeric: []intervalSnapshot{
+					{Start: "> 5.0.0.0", End: "< 6.0.0.0"},
+					{Start: "> 6.0.0.0", End: "< +Inf"},
+				},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "disjunctive constraints keeps branch intervals if numeric is provided",
+			constraint: "!= dev-master, != dev-foo || > 5",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{"dev-foo", "dev-master"}, Exclude: true},
+			},
+		},
+		{
+			name:       "conjunctive constraints should be intersected",
+			constraint: "^1.0, ^1.2",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 1.2.0.0-dev", End: "< 2.0.0.0-dev"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "conjunctive constraints should be intersected/2",
+			constraint: "^1.0, ^1.2, 1.4 - 1.8, 1.5 - 1.6, 1.5 - 2",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 1.5.0.0-dev", End: "< 1.7.0.0-dev"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "conjunctive constraints simple",
+			constraint: "1.5 - 2",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 1.5.0.0-dev", End: "< 3.0.0.0-dev"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "conjunctive constraints with dev exclusions",
+			constraint: "!= 1.4.5, ^1.0, != 1.2.3, != 2.3, != dev-foo, != dev-master",
+			expected: domainSnapshot{
+				Numeric: []intervalSnapshot{
+					{Start: ">= 1.0.0.0-dev", End: "< 1.2.3.0"},
+					{Start: "> 1.2.3.0", End: "< 1.4.5.0"},
+					{Start: "> 1.4.5.0", End: "< 2.0.0.0-dev"},
+				},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "conjunctive constraints with dev exact versions suppresses the number scope matches",
+			constraint: "!= 1.4.5, ^1.0, != 1.2.3, != 2.3, == dev-foo, == dev-foo",
+			expected:   domainSnapshot{Branches: noDev},
+		},
+		{
+			name:       "conjunctive constraints with dev exact versions suppresses number scope but keeps dev when allowed",
+			constraint: "!= 1.2.3, != 2.3, == dev-foo, == dev-foo",
+			expected:   domainSnapshot{Branches: branchSnapshot{Names: []string{"dev-foo"}}},
+		},
+		{
+			name:       "disjunctive constraints with exclusions in dev constraints makes number scope match any",
+			constraint: "^1.0 || != dev-foo",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{"dev-foo"}, Exclude: true},
+			},
+		},
+		{
+			name:       "disjunctive constraints with exclusions, if matches all numeric and dev, then any",
+			constraint: "!= 1.4.5 || ^1.0 || != dev-foo || != dev-master || == dev-master",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{}, Exclude: true},
+			},
+		},
+		{
+			name:       "disjunctive constraints with exclusions, if dev constraints match all, then any",
+			constraint: "^1.0 || != dev-master || == dev-master",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{}, Exclude: true},
+			},
+		},
+		{
+			name:       "disjunctive constraints with exclusions, dev scope excluded only",
+			constraint: "^1.0 || != dev-foo || == dev-master",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{"dev-foo"}, Exclude: true},
+			},
+		},
+		{
+			name:       "disjunctive constraints with exact dev matches returns numeric and unique dev constraints",
+			constraint: "^1.0 || == dev-foo || == dev-master || == dev-master",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 1.0.0.0-dev", End: "< 2.0.0.0-dev"}},
+				Branches: branchSnapshot{Names: []string{"dev-foo", "dev-master"}},
+			},
+		},
+		{
+			name:       "conjunctive constraints with exact versions",
+			constraint: "dev-master, ^1.0",
+			expected:   domainSnapshot{Branches: noDev},
+		},
+		{
+			name:       "conjunctive constraints with exact versions, dev only, diff version",
+			constraint: "dev-master, dev-foo",
+			expected:   domainSnapshot{Branches: noDev},
+		},
+		{
+			name:       "conjunctive constraints with exact versions, dev only, same version",
+			constraint: "dev-master, dev-master",
+			expected:   domainSnapshot{Branches: branchSnapshot{Names: []string{"dev-master"}}},
+		},
+		{
+			name:       "conjunctive constraints with same dev exclusion",
+			constraint: "!= dev-master, != dev-master",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{"dev-master"}, Exclude: true},
+			},
+		},
+		{
+			name:       "conjunctive constraints with different dev exclusions",
+			constraint: "!= dev-master, != dev-foo",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{"dev-foo", "dev-master"}, Exclude: true},
+			},
+		},
+		{
+			name:       "disjunctive constraints with exact versions",
+			constraint: "dev-master || ^1.0 || dev-foo || dev-master",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 1.0.0.0-dev", End: "< 2.0.0.0-dev"}},
+				Branches: branchSnapshot{Names: []string{"dev-foo", "dev-master"}},
+			},
+		},
+		{
+			name:       "conjunctive constraints with star should skip it",
+			constraint: "^1.0, *",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 1.0.0.0-dev", End: "< 2.0.0.0-dev"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "disjunctive constraints with star should result in any",
+			constraint: "^1.0 || *",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{}, Exclude: true},
+			},
+		},
+		{
+			name:       "conjunctive constraints with only star should result in any",
+			constraint: "*, *",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{}, Exclude: true},
+			},
+		},
+		{
+			name:       "disjunctive constraints with star and dev exclusion should not return exclusion",
+			constraint: "!= dev-foo || *",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{}, Exclude: true},
+			},
+		},
+		{
+			name:       "conjunctive constraints with various dev constraints/2",
+			constraint: "> 5, *",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: "> 5.0.0.0", End: "< +Inf"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "conjunctive constraints with various dev constraints/3",
+			constraint: "!= dev-foo, > 5",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: "> 5.0.0.0", End: "< +Inf"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:       "conjunctive constraints with various dev constraints/4",
+			constraint: "!= dev-foo, != dev-foo",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{"dev-foo"}, Exclude: true},
+			},
+		},
+		{
+			name:       "conjunctive constraints with various dev constraints/5",
+			constraint: "!= dev-foo, != dev-bar",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{"dev-bar", "dev-foo"}, Exclude: true},
+			},
+		},
+		{
+			name:       "conjunctive constraints with various dev constraints/6",
+			constraint: "!= dev-foo, == dev-bar",
+			expected:   domainSnapshot{Branches: branchSnapshot{Names: []string{"dev-bar"}}},
+		},
+		{
+			name:       "conjunctive constraints with various dev constraints/7",
+			constraint: "dev-foo, > 5",
+			expected:   domainSnapshot{Branches: noDev},
+		},
+		{
+			name:       "complex conjunctive which can not match anything",
+			constraint: "!= 1.0, != 1.0, != dev-foo, 1.0.5.*, == dev-bla",
+			expected:   domainSnapshot{Branches: noDev},
+		},
+		{
+			name:       "disjunctive constraints with various dev constraints",
+			constraint: "!= dev-foo, != dev-bar || != dev-foo",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{"dev-foo"}, Exclude: true},
+			},
+		},
+		{
+			name:       "disjunctive constraints with various dev constraints/2",
+			constraint: "!= dev-foo, != dev-bar || != dev-foo, != dev-bar",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{"dev-bar", "dev-foo"}, Exclude: true},
+			},
+		},
+		{
+			name:       "disjunctive constraints with various dev constraints/4",
+			constraint: "== dev-foo || == dev-bar",
+			expected:   domainSnapshot{Branches: branchSnapshot{Names: []string{"dev-bar", "dev-foo"}}},
+		},
+		{
+			name:       "disjunctive constraints with various dev constraints/5",
+			constraint: "== dev-foo || != dev-foo",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{}, Exclude: true},
+			},
+		},
+		{
+			name:       "disjunctive constraints with various dev constraints/6",
+			constraint: "== dev-foo || != dev-bar",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{"dev-bar"}, Exclude: true},
+			},
+		},
+		{
+			name:       "disjunctive constraints with various dev constraints/7",
+			constraint: "== dev-foo || != dev-bar || != dev-bar",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{"dev-bar"}, Exclude: true},
+			},
+		},
+		{
+			name:       "disjunctive constraints with various dev constraints/8",
+			constraint: "== dev-foo || != dev-bar || != dev-foo",
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+				Branches: branchSnapshot{Names: []string{}, Exclude: true},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		domains, err := constraintUnionDomains(tc.constraint)
+		if err != nil {
+			t.Errorf("%s: constraintUnionDomains(%q) unexpected error: %v", tc.name, tc.constraint, err)
+			continue
+		}
+		actual := domainUnionSnapshot(domains)
+		if !reflect.DeepEqual(actual, tc.expected) {
+			t.Errorf("%s: expected %#v, got %#v", tc.name, tc.expected, actual)
+		}
+	}
+}
+
+func TestIntervalsGetComposedCases(t *testing.T) {
+	noDev := branchSnapshot{Names: []string{}}
+	tests := []struct {
+		name        string
+		parts       []string
+		conjunctive bool
+		expected    domainSnapshot
+	}{
+		{
+			name: "conjunctive constraints should be intersected, not flattened by version parser",
+			parts: []string{
+				">=1.0.0.0-dev <2.0.0.0-dev",
+				">=1.2.0.0-dev <2.0.0.0-dev",
+				">=1.4.0.0-dev <1.9.0.0-dev",
+				">=1.5.0.0-dev <1.7.0.0-dev",
+				">=1.5.0.0-dev <3.0.0.0-dev",
+			},
+			conjunctive: true,
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 1.5.0.0-dev", End: "< 1.7.0.0-dev"}},
+				Branches: noDev,
+			},
+		},
+		{
+			name:        "conjunctive constraints with disjunctive subcomponents should be intersected",
+			parts:       []string{"1.0 - 1.2 || ^1.5", "1.8 - 1.9 || ^1.12"},
+			conjunctive: true,
+			expected: domainSnapshot{
+				Numeric: []intervalSnapshot{
+					{Start: ">= 1.8.0.0-dev", End: "< 1.10.0.0-dev"},
+					{Start: ">= 1.12.0.0-dev", End: "< 2.0.0.0-dev"},
+				},
+				Branches: noDev,
+			},
+		},
+		{
+			name:        "conjunctive constraints with equal constraints",
+			parts:       []string{"1.3.1.0-dev || 1.3.2.0-dev || 1.3.3.0-dev", "1.3.2.0-dev"},
+			conjunctive: true,
+			expected: domainSnapshot{
+				Numeric:  []intervalSnapshot{{Start: ">= 1.3.2.0-dev", End: "<= 1.3.2.0-dev"}},
+				Branches: noDev,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		domains, err := composeConstraintDomains(tc.parts, tc.conjunctive)
+		if err != nil {
+			t.Errorf("%s: composeConstraintDomains unexpected error: %v", tc.name, err)
+			continue
+		}
+		actual := domainUnionSnapshot(domains)
+		if !reflect.DeepEqual(actual, tc.expected) {
+			t.Errorf("%s: expected %#v, got %#v", tc.name, tc.expected, actual)
+		}
+	}
+}
+
+func TestMatcherAndSpecialConstraintBehavior(t *testing.T) {
+	satisfies := []struct {
+		version    string
+		constraint string
+		expected   bool
+	}{
+		{"2", ">=1", true},
+		{"1.0", ">=2.11", false},
+		{"11.0", ">=2.1", true},
+		{"1.1", "*", true},
+		{"1.1", "^1.0, ^2.0", false},
+		{"2.0", "^1.0, ^2.0", false},
+		{"dev-foo", "^1.0, ^2.0", false},
+	}
+
+	for _, tc := range satisfies {
+		actual, err := checkSatisfiesForTest(tc.version, tc.constraint)
+		if err != nil {
+			t.Errorf("Satisfies(%q, %q) unexpected error: %v", tc.version, tc.constraint, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("Satisfies(%q, %q): expected %v, got %v", tc.version, tc.constraint, tc.expected, actual)
+		}
+	}
+
+	if c := MustConstraints(NewConstraint("*")); c.String() != "*" {
+		t.Errorf("match-all string: expected %q, got %q", "*", c.String())
+	}
+}
+
+func TestMultiConstraintBehavior(t *testing.T) {
+	intersections := []struct {
+		left     string
+		right    string
+		expected bool
+	}{
+		{">1.0 <1.2", "1.1", true},
+		{">1.0 <1.2", ">=1.1 <2.0", true},
+		{">1.0 || <1.2", ">1.0 || <1.2", true},
+		{">1.0 <1.2", "<1.0 || >2.0", false},
+		{">1.0 <1.2", "1.2", false},
+		{">dev-foo || >dev-bar", "1.1", false},
+		{"!=dev-foo, !=dev-bar", "!=1.1", true},
+		{"^7.0", ">=7.0.0-dev <8.0.0-dev", true},
+		{"^7.2", ">=7.2.0-dev <8.0.0-dev", true},
+		{"7.4.*", ">=7.4.0-dev <7.5.0-dev", true},
+		{"7.2.* || 7.4.*", ">=7.2.0-dev <7.5.0-dev", true},
+		{"^7.1.15 || ^7.2.3", "^7.2.2", true},
+	}
+
+	for _, tc := range intersections {
+		actual, err := ConstraintIntersects(tc.left, tc.right)
+		if err != nil {
+			t.Errorf("ConstraintIntersects(%q, %q) unexpected error: %v", tc.left, tc.right, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("ConstraintIntersects(%q, %q): expected %v, got %v", tc.left, tc.right, tc.expected, actual)
+		}
+	}
+
+	subsets := []struct {
+		left     string
+		right    string
+		expected bool
+	}{
+		{"^2.5 || ^3.0", ">=2.5.0-dev <4.0.0-dev", true},
+		{"^2.5 || ^3.0 || ^4.0", ">=2.5.0-dev <5.0.0-dev", true},
+		{"~2.5.9 || ~2.6, >=2.6.2", "~2.5.9 || ~2.6, >=2.6.2", true},
+		{"^0.2 || ^1.0", ">=0.2.0-dev <0.3.0-dev || >=1.0.0-dev <2.0.0-dev", true},
+		{"^0.1 || ^1.0 || ^2.0", ">=0.1.0-dev <0.2.0-dev || >=1.0.0-dev <3.0.0-dev", true},
+		{"^1.0 || 2.1 || ^3.0", "^1.0 || 2.1 || ^3.0", true},
+	}
+
+	for _, tc := range subsets {
+		actual, err := ConstraintSubsetOf(tc.left, tc.right)
+		if err != nil {
+			t.Errorf("ConstraintSubsetOf(%q, %q) unexpected error: %v", tc.left, tc.right, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("ConstraintSubsetOf(%q, %q): expected %v, got %v", tc.left, tc.right, tc.expected, actual)
+		}
+	}
+}
+
+func TestMultiConstraintMatchAllCreate(t *testing.T) {
+	all := domainSnapshot{
+		Numeric:  []intervalSnapshot{{Start: ">= 0.0.0.0-dev", End: "< +Inf"}},
+		Branches: branchSnapshot{Names: []string{}, Exclude: true},
+	}
+
+	empty, err := composeConstraintDomains(nil, true)
+	if err != nil {
+		t.Fatalf("composeConstraintDomains(nil, true) unexpected error: %v", err)
+	}
+	if actual := domainUnionSnapshot(empty); !reflect.DeepEqual(actual, all) {
+		t.Fatalf("empty conjunctive multi: expected %#v, got %#v", all, actual)
+	}
+
+	conjunctive, err := composeConstraintDomains([]string{">=2.5.0.0-dev", "<=3.0.0.0-dev", "*"}, true)
+	if err != nil {
+		t.Fatalf("composeConstraintDomains conjunctive unexpected error: %v", err)
+	}
+	expectedConjunctive, err := constraintUnionDomains(">=2.5.0.0-dev <=3.0.0.0-dev")
+	if err != nil {
+		t.Fatalf("expected conjunctive constraint unexpected error: %v", err)
+	}
+	if !domainUnionsEquivalent(conjunctive, expectedConjunctive) {
+		t.Errorf("match-all inside conjunctive multi should be skipped")
+	}
+
+	disjunctive, err := composeConstraintDomains([]string{">=2.5.0.0-dev", "*"}, false)
+	if err != nil {
+		t.Fatalf("composeConstraintDomains disjunctive unexpected error: %v", err)
+	}
+	if actual := domainUnionSnapshot(disjunctive); !reflect.DeepEqual(actual, all) {
+		t.Errorf("match-all inside disjunctive multi: expected %#v, got %#v", all, actual)
+	}
+}
+
+func TestMultiConstraintOptimizationCases(t *testing.T) {
+	tests := []struct {
+		name       string
+		constraint string
+		expected   string
+	}{
+		{"collapses contiguous", "^2.5 || ^3.0", ">=2.5.0-dev <4.0.0-dev"},
+		{"collapses multiple contiguous", "^2.5 || ^3.0 || ^4.0", ">=2.5.0-dev <5.0.0-dev"},
+		{"does not collapse when one side is more complex", "~2.5.9 || ~2.6, >=2.6.2", "~2.5.9 || ~2.6, >=2.6.2"},
+		{"collapses only the simple contiguous tail", "^1.0 || ^2.0 !=2.0.1 || ^3.0 || ^4.0", "^1.0 || ^2.0 !=2.0.1 || >=3.0.0-dev <5.0.0-dev"},
+		{"does not collapse contiguous ranges with exclusions", "^1.0 != 1.0.1 || ^2.0 !=2.0.1 || ^3.0 || ^4.0 != 4.0.1", "^1.0 !=1.0.1 || ^2.0 !=2.0.1 || ^3.0 || ^4.0 !=4.0.1"},
+		{"does not collapse if another constraint also applies", "~0.1 || ~1.0 !=1.0.1", "~0.1 || ~1.0 !=1.0.1"},
+		{"does not collapse non-contiguous caret ranges", "^0.2 || ^1.0", "^0.2 || ^1.0"},
+		{"collapses following contiguous ranges after a gap", "^0.1 || ^1.0 || ^2.0", "^0.1 || >=1.0.0-dev <3.0.0-dev"},
+		{"does not collapse exact constraint outside range", "^1.0 || 2.1 || ^3.0", "^1.0 || 2.1 || ^3.0"},
+	}
+
+	for _, tc := range tests {
+		actual, err := constraintUnionDomains(tc.constraint)
+		if err != nil {
+			t.Errorf("%s: constraintUnionDomains(%q) unexpected error: %v", tc.name, tc.constraint, err)
+			continue
+		}
+		expected, err := constraintUnionDomains(tc.expected)
+		if err != nil {
+			t.Errorf("%s: expected constraint %q unexpected error: %v", tc.name, tc.expected, err)
+			continue
+		}
+		if !domainUnionsEquivalent(actual, expected) {
+			t.Errorf("%s: expected %q to be equivalent to %q", tc.name, tc.constraint, tc.expected)
+		}
+	}
+}
+
+func TestSemverInvalidConstraint(t *testing.T) {
+	tests := []string{
+		"",
+		"1.0.0-meh",
+		">2.0,,<=3.0",
+		">2.0 ,, <=3.0",
+		">2.0 ||| <=3.0",
+		",^1@dev || ^4@dev",
+		",^1@dev",
+		"|| ^1@dev",
+		"^1@dev ||",
+		"^1@dev ,",
+		"^2.0.*",
+		"^2.0.x",
+		"^2.0.x-beta",
+		"^2.*",
+		"^2.x",
+		"^2.x-beta",
+		"^2.1.2.*",
+		"^2.1.2.x",
+		"^2.1.2.x-beta",
+		"~2.0.*",
+		"~2.0.x",
+		"~2.0.x-beta",
+		"~2.*",
+		"~2.x",
+		"~2.x-beta",
+		"~2.1.2.*",
+		"~2.1.2.x",
+		"~2.1.2.x-beta",
+		"1.x - 2.*",
+		"2.x.x.x-dev - 3.x.x.x-dev",
+		"^1.*-beta-dev",
+		"^1. *-dev",
+		"~1.*-beta-dev",
+		"1.0.0-dev<1.0.5-dev",
+		"*-dev",
+		"~>1.2",
+		"^",
+		"^8 || ^",
+		"~",
+		"~1 ~",
+	}
+
+	for _, constraint := range tests {
+		t.Run(constraint, func(t *testing.T) {
+			if _, err := NewConstraint(constraint); err == nil {
+				t.Fatalf("expected constraint %q to be rejected", constraint)
+			}
+		})
+	}
+}
+
+func checkSatisfiesForTest(versionString, constraintString string) (bool, error) {
+	constraint, err := NewConstraint(constraintString)
+	if err != nil {
+		return false, err
+	}
+
+	v, err := NewVersion(versionString)
+	if err != nil {
+		return false, err
+	}
+
+	return constraint.Check(v), nil
+}
+
+func satisfiedByForTest(constraintString string, versions []string) ([]string, error) {
+	matches := make([]string, 0, len(versions))
+	for _, versionString := range versions {
+		ok, err := checkSatisfiesForTest(versionString, constraintString)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			matches = append(matches, versionString)
+		}
+	}
+	return matches, nil
+}
+
+func compareForTest(version1, operator, version2 string) (bool, error) {
+	v1, err := NewVersion(version1)
+	if err != nil {
+		return false, err
+	}
+
+	v2, err := NewVersion(version2)
+	if err != nil {
+		return false, err
+	}
+
+	switch operator {
+	case "=", "==":
+		return v1.Equal(v2), nil
+	case "!=", "<>":
+		return !v1.Equal(v2), nil
+	case ">":
+		return v1.GreaterThan(v2), nil
+	case ">=":
+		return v1.GreaterThanOrEqual(v2), nil
+	case "<":
+		return v1.LessThan(v2), nil
+	case "<=":
+		return v1.LessThanOrEqual(v2), nil
+	default:
+		return false, fmt.Errorf("unsupported operator: %s", operator)
+	}
+}
+
+func mustVersions(t *testing.T, versions []string) []*Version {
+	t.Helper()
+
+	result := make([]*Version, len(versions))
+	for i, versionString := range versions {
+		v, err := NewVersion(versionString)
+		if err != nil {
+			t.Fatalf("NewVersion(%q) unexpected error: %v", versionString, err)
+		}
+		result[i] = v
+	}
+	return result
+}
+
+func versionOriginals(versions []*Version) []string {
+	result := make([]string, len(versions))
+	for i, v := range versions {
+		result[i] = v.Original()
+	}
+	return result
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/snapshot.go
+++ b/snapshot.go
@@ -1,0 +1,346 @@
+package version
+
+import (
+	"fmt"
+	"sort"
+)
+
+// This file holds the snapshot layer: serializable representations of domains,
+// intervals, and bounds plus the helpers that render them. These are used to
+// summarize and format constraint domains.
+
+type boundSnapshot struct {
+	Version   string
+	Inclusive bool
+}
+
+type intervalSnapshot struct {
+	Start string
+	End   string
+}
+
+type branchSnapshot struct {
+	Names   []string
+	Exclude bool
+}
+
+type domainSnapshot struct {
+	Numeric  []intervalSnapshot
+	Branches branchSnapshot
+}
+
+func constraintBoundsSnapshot(operator, version string) (boundSnapshot, boundSnapshot, error) {
+	v, err := NewVersion(version)
+	if err != nil {
+		return boundSnapshot{}, boundSnapshot{}, err
+	}
+
+	if v.branch != "" && operator != "" && operator != "=" && operator != "==" {
+		return zeroBoundSnapshot(), positiveInfinityBoundSnapshot(), nil
+	}
+
+	bound := versionBoundSnapshot(v, true)
+	switch operator {
+	case "", "=", "==":
+		return bound, bound, nil
+	case "<":
+		return zeroBoundSnapshot(), versionBoundSnapshot(v, false), nil
+	case "<=":
+		return zeroBoundSnapshot(), bound, nil
+	case ">":
+		return versionBoundSnapshot(v, false), positiveInfinityBoundSnapshot(), nil
+	case ">=":
+		return bound, positiveInfinityBoundSnapshot(), nil
+	case "!=", "<>":
+		return zeroBoundSnapshot(), positiveInfinityBoundSnapshot(), nil
+	default:
+		return boundSnapshot{}, boundSnapshot{}, nil
+	}
+}
+
+func domainUnionBoundsSnapshot(domains []constraintDomain) (boundSnapshot, boundSnapshot) {
+	intervals := unionNumericIntervals(domains)
+	if len(intervals) == 0 {
+		return zeroBoundSnapshot(), positiveInfinityBoundSnapshot()
+	}
+
+	var lower *versionBound
+	var upper *versionBound
+	initialized := false
+	for _, interval := range intervals {
+		if !initialized {
+			lower = interval.lower
+			upper = interval.upper
+			initialized = true
+			continue
+		}
+		lower = minLowerBound(lower, interval.lower)
+		upper = maxUpper(upper, interval.upper)
+	}
+
+	return snapshotLowerBound(lower), snapshotUpperBound(upper)
+}
+
+func combineRawConstraintBoundsSnapshot(parts []string, conjunctive bool) (boundSnapshot, boundSnapshot, error) {
+	if len(parts) == 0 {
+		return zeroBoundSnapshot(), positiveInfinityBoundSnapshot(), nil
+	}
+
+	var lower boundSnapshot
+	var upper boundSnapshot
+	for i, part := range parts {
+		operator, version, _, ok := splitConstraintParts(part)
+		if !ok {
+			return boundSnapshot{}, boundSnapshot{}, fmt.Errorf("malformed constraint: %s", part)
+		}
+		partLower, partUpper, err := constraintBoundsSnapshot(operator, version)
+		if err != nil {
+			return boundSnapshot{}, boundSnapshot{}, err
+		}
+
+		if i == 0 {
+			lower = partLower
+			upper = partUpper
+			continue
+		}
+
+		if conjunctive {
+			lower = maxLowerSnapshot(lower, partLower)
+			upper = minUpperSnapshot(upper, partUpper)
+		} else {
+			lower = minLowerSnapshot(lower, partLower)
+			upper = maxUpperSnapshot(upper, partUpper)
+		}
+	}
+
+	return lower, upper, nil
+}
+
+func maxLowerSnapshot(left, right boundSnapshot) boundSnapshot {
+	cmp := compareBoundSnapshotVersions(left.Version, right.Version)
+	if cmp > 0 {
+		return left
+	}
+	if cmp < 0 {
+		return right
+	}
+	return boundSnapshot{Version: left.Version, Inclusive: left.Inclusive && right.Inclusive}
+}
+
+func minLowerSnapshot(left, right boundSnapshot) boundSnapshot {
+	cmp := compareBoundSnapshotVersions(left.Version, right.Version)
+	if cmp < 0 {
+		return left
+	}
+	if cmp > 0 {
+		return right
+	}
+	return boundSnapshot{Version: left.Version, Inclusive: left.Inclusive || right.Inclusive}
+}
+
+func minUpperSnapshot(left, right boundSnapshot) boundSnapshot {
+	cmp := compareBoundSnapshotVersions(left.Version, right.Version)
+	if cmp < 0 {
+		return left
+	}
+	if cmp > 0 {
+		return right
+	}
+	return boundSnapshot{Version: left.Version, Inclusive: left.Inclusive && right.Inclusive}
+}
+
+func maxUpperSnapshot(left, right boundSnapshot) boundSnapshot {
+	cmp := compareBoundSnapshotVersions(left.Version, right.Version)
+	if cmp > 0 {
+		return left
+	}
+	if cmp < 0 {
+		return right
+	}
+	return boundSnapshot{Version: left.Version, Inclusive: left.Inclusive || right.Inclusive}
+}
+
+func compareBoundSnapshotVersions(left, right string) int {
+	if left == right {
+		return 0
+	}
+	if left == "+Inf" {
+		return 1
+	}
+	if right == "+Inf" {
+		return -1
+	}
+	leftVersion := Must(NewVersion(left))
+	rightVersion := Must(NewVersion(right))
+	return leftVersion.Compare(rightVersion)
+}
+
+func snapshotLowerBound(bound *versionBound) boundSnapshot {
+	if bound == nil {
+		return zeroBoundSnapshot()
+	}
+	return versionBoundSnapshot(bound.version, bound.inclusive)
+}
+
+func snapshotUpperBound(bound *versionBound) boundSnapshot {
+	if bound == nil {
+		return positiveInfinityBoundSnapshot()
+	}
+	return versionBoundSnapshot(bound.version, bound.inclusive)
+}
+
+func versionBoundSnapshot(v *Version, inclusive bool) boundSnapshot {
+	return boundSnapshot{Version: v.NormalizedString(), Inclusive: inclusive}
+}
+
+func zeroBoundSnapshot() boundSnapshot {
+	return boundSnapshot{Version: "0.0.0.0-dev", Inclusive: true}
+}
+
+func positiveInfinityBoundSnapshot() boundSnapshot {
+	return boundSnapshot{Version: "+Inf", Inclusive: false}
+}
+
+func domainUnionSnapshot(domains []constraintDomain) domainSnapshot {
+	return domainSnapshot{
+		Numeric:  snapshotNumericIntervals(unionNumericIntervals(domains)),
+		Branches: snapshotBranches(domains),
+	}
+}
+
+func snapshotNumericIntervals(intervals []versionInterval) []intervalSnapshot {
+	segments := splitIntervalExclusions(intervals)
+	if len(segments) == 0 {
+		return nil
+	}
+
+	sort.Slice(segments, func(i, j int) bool {
+		return lowerBefore(segments[i].lower, segments[j].lower)
+	})
+
+	merged := make([]versionInterval, 0, len(segments))
+	for _, interval := range segments {
+		if !intervalHasAnyVersion(interval) {
+			continue
+		}
+		if len(merged) == 0 {
+			merged = append(merged, interval)
+			continue
+		}
+		last := &merged[len(merged)-1]
+		if intervalsCanMerge(*last, interval) {
+			last.upper = maxUpper(last.upper, interval.upper)
+			continue
+		}
+		merged = append(merged, interval)
+	}
+
+	snapshots := make([]intervalSnapshot, 0, len(merged))
+	for _, interval := range merged {
+		snapshots = append(snapshots, intervalSnapshot{
+			Start: formatLowerBound(interval.lower),
+			End:   formatUpperBound(interval.upper),
+		})
+	}
+	return snapshots
+}
+
+func splitIntervalExclusions(intervals []versionInterval) []versionInterval {
+	var result []versionInterval
+	for _, interval := range intervals {
+		if !intervalHasAnyVersion(interval) {
+			continue
+		}
+
+		exclusions := intervalExclusionsInside(interval)
+		if len(exclusions) == 0 {
+			result = append(result, versionInterval{lower: interval.lower, upper: interval.upper})
+			continue
+		}
+
+		lower := interval.lower
+		for _, exclusion := range exclusions {
+			before := versionInterval{
+				lower: lower,
+				upper: exclusiveBound(exclusion),
+			}
+			if intervalHasAnyVersion(before) {
+				result = append(result, before)
+			}
+			lower = exclusiveBound(exclusion)
+		}
+
+		after := versionInterval{
+			lower: lower,
+			upper: interval.upper,
+		}
+		if intervalHasAnyVersion(after) {
+			result = append(result, after)
+		}
+	}
+	return result
+}
+
+func intervalExclusionsInside(interval versionInterval) []*Version {
+	seen := map[string]*Version{}
+	for _, exclusion := range interval.exclusions {
+		if versionInInterval(exclusion, interval, false) {
+			seen[exclusion.NormalizedString()] = exclusion
+		}
+	}
+
+	exclusions := make([]*Version, 0, len(seen))
+	for _, exclusion := range seen {
+		exclusions = append(exclusions, exclusion)
+	}
+	sort.Slice(exclusions, func(i, j int) bool {
+		return exclusions[i].LessThan(exclusions[j])
+	})
+	return exclusions
+}
+
+func formatLowerBound(bound *versionBound) string {
+	if bound == nil {
+		return ">= 0.0.0.0-dev"
+	}
+	operator := ">="
+	if !bound.inclusive {
+		operator = ">"
+	}
+	return operator + " " + bound.version.NormalizedString()
+}
+
+func formatUpperBound(bound *versionBound) string {
+	if bound == nil {
+		return "< +Inf"
+	}
+	operator := "<="
+	if !bound.inclusive {
+		operator = "<"
+	}
+	return operator + " " + bound.version.NormalizedString()
+}
+
+func snapshotBranches(domains []constraintDomain) branchSnapshot {
+	if unionHasAnyBranch(domains) {
+		names := stringSetKeys(branchesExcludedByEveryAnyBranch(domains))
+		return branchSnapshot{Names: names, Exclude: true}
+	}
+
+	names := map[string]struct{}{}
+	for _, domain := range domains {
+		for branch := range domain.branches {
+			names[branch] = struct{}{}
+		}
+	}
+	return branchSnapshot{Names: stringSetKeys(names)}
+}
+
+func stringSetKeys(values map[string]struct{}) []string {
+	result := make([]string, 0, len(values))
+	for value := range values {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/testdata/fuzz/FuzzNewVersion/c744251721e30157
+++ b/testdata/fuzz/FuzzNewVersion/c744251721e30157
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\x95")

--- a/testdata/fuzz/FuzzNewVersion/d29f270a982e6001
+++ b/testdata/fuzz/FuzzNewVersion/d29f270a982e6001
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("000000")

--- a/testdata/fuzz/FuzzNormalizeComposerVersion/9bf8a2cda79b9604
+++ b/testdata/fuzz/FuzzNormalizeComposerVersion/9bf8a2cda79b9604
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("9227000000000000000")

--- a/testdata/fuzz/FuzzNormalizeComposerVersion/d6fdc4cffec6d87d
+++ b/testdata/fuzz/FuzzNormalizeComposerVersion/d6fdc4cffec6d87d
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0000-00")

--- a/version.go
+++ b/version.go
@@ -25,11 +25,11 @@ const (
 
 // Version represents a single version.
 type Version struct {
-	metadata string
 	pre      string
 	segments []int64
 	si       int
 	original string
+	branch   string
 }
 
 func init() {
@@ -47,6 +47,15 @@ func newVersionFromRegExp(v string, pattern *regexp.Regexp) (*Version, error) {
 
 	if err != nil {
 		return nil, err
+	}
+
+	if strings.HasPrefix(strings.ToLower(normalized), "dev-") {
+		return &Version{
+			pre:      "dev",
+			segments: []int64{0, 0, 0},
+			original: v,
+			branch:   normalized,
+		}, nil
 	}
 
 	matches := pattern.FindStringSubmatch(normalized)
@@ -80,7 +89,6 @@ func newVersionFromRegExp(v string, pattern *regexp.Regexp) (*Version, error) {
 	}
 
 	return &Version{
-		metadata: matches[10],
 		pre:      pre,
 		segments: segments,
 		si:       si,
@@ -110,6 +118,19 @@ func (v *Version) Compare(other *Version) int {
 		return 0
 	}
 
+	if v.branch != "" || other.branch != "" {
+		if v.branch == "" {
+			return 1
+		}
+		if other.branch == "" {
+			return -1
+		}
+		if v.branch < other.branch {
+			return -1
+		}
+		return 1
+	}
+
 	segmentsSelf := v.Segments64()
 	segmentsOther := other.Segments64()
 
@@ -121,9 +142,15 @@ func (v *Version) Compare(other *Version) int {
 			return 0
 		}
 		if preSelf == "" {
+			if parsePrereleasePart(preOther).rank == prereleaseRankPatch {
+				return -1
+			}
 			return 1
 		}
 		if preOther == "" {
+			if parsePrereleasePart(preSelf).rank == prereleaseRankPatch {
+				return 1
+			}
 			return -1
 		}
 
@@ -182,6 +209,67 @@ func allZero(segs []int64) bool {
 	return true
 }
 
+type prereleasePart struct {
+	rank        int
+	suffix      string
+	hasSuffix   bool
+	suffixValue int64
+	suffixNum   bool
+}
+
+const (
+	prereleaseRankDev = iota
+	prereleaseRankAlpha
+	prereleaseRankBeta
+	prereleaseRankRC
+	prereleaseRankStable
+	prereleaseRankPatch
+	prereleaseRankOther
+)
+
+func parsePrereleasePart(part string) prereleasePart {
+	lower := strings.ToLower(part)
+	for _, prefix := range []struct {
+		name string
+		rank int
+	}{
+		{"dev", prereleaseRankDev},
+		{"alpha", prereleaseRankAlpha},
+		{"beta", prereleaseRankBeta},
+		{"rc", prereleaseRankRC},
+		{"stable", prereleaseRankStable},
+		{"patch", prereleaseRankPatch},
+	} {
+		if strings.HasPrefix(lower, prefix.name) {
+			suffix := part[len(prefix.name):]
+			parsed := prereleasePart{
+				rank:      prefix.rank,
+				suffix:    suffix,
+				hasSuffix: suffix != "",
+			}
+			if suffix != "" {
+				if value, err := strconv.ParseInt(suffix, 10, 64); err == nil {
+					parsed.suffixValue = value
+					parsed.suffixNum = true
+				}
+			}
+			return parsed
+		}
+	}
+
+	parsed := prereleasePart{
+		rank:      prereleaseRankOther,
+		suffix:    part,
+		hasSuffix: part != "",
+	}
+	if value, err := strconv.ParseInt(part, 10, 64); err == nil {
+		parsed.rank = prereleaseRankStable
+		parsed.suffixValue = value
+		parsed.suffixNum = true
+	}
+	return parsed
+}
+
 func comparePart(preSelf string, preOther string) int {
 	if preSelf == preOther {
 		return 0
@@ -211,6 +299,40 @@ func comparePart(preSelf string, preOther string) int {
 
 	if preOther == "" {
 		if selfNumeric {
+			return 1
+		}
+		return -1
+	}
+
+	selfPart := parsePrereleasePart(preSelf)
+	otherPart := parsePrereleasePart(preOther)
+	if selfPart.rank != otherPart.rank {
+		if selfPart.rank < otherPart.rank {
+			return -1
+		}
+		return 1
+	}
+
+	if selfPart.rank != prereleaseRankOther {
+		if !selfPart.hasSuffix && !otherPart.hasSuffix {
+			return 0
+		}
+		if !selfPart.hasSuffix {
+			return -1
+		}
+		if !otherPart.hasSuffix {
+			return 1
+		}
+		if selfPart.suffixNum && otherPart.suffixNum {
+			if selfPart.suffixValue == otherPart.suffixValue {
+				return 0
+			}
+			if selfPart.suffixValue < otherPart.suffixValue {
+				return -1
+			}
+			return 1
+		}
+		if selfPart.suffix > otherPart.suffix {
 			return 1
 		}
 		return -1
@@ -269,38 +391,55 @@ func comparePrereleases(v string, other string) int {
 	return 0
 }
 
+// bothBranches reports whether both versions are dev-branch versions, which
+// Composer treats as unordered: they only compare meaningfully for equality.
+func (v *Version) bothBranches(o *Version) bool {
+	return v.branch != "" && o.branch != ""
+}
+
 // Equal tests if two versions are equal.
 func (v *Version) Equal(o *Version) bool {
+	if v.bothBranches(o) {
+		return v.branch == o.branch
+	}
+
 	return v.Compare(o) == 0
 }
 
 // GreaterThan tests if this version is greater than another version.
 func (v *Version) GreaterThan(o *Version) bool {
+	if v.bothBranches(o) {
+		return false
+	}
+
 	return v.Compare(o) > 0
 }
 
 // GreaterThanOrEqual tests if this version is greater than or equal to another version.
 func (v *Version) GreaterThanOrEqual(o *Version) bool {
+	if v.bothBranches(o) {
+		return v.branch == o.branch
+	}
+
 	return v.Compare(o) >= 0
 }
 
 // LessThan tests if this version is less than another version.
 func (v *Version) LessThan(o *Version) bool {
+	if v.bothBranches(o) {
+		return false
+	}
+
 	return v.Compare(o) < 0
 }
 
 // LessThanOrEqual tests if this version is less than or equal to another version.
 func (v *Version) LessThanOrEqual(o *Version) bool {
-	return v.Compare(o) <= 0
-}
+	if v.bothBranches(o) {
+		return v.branch == o.branch
+	}
 
-// Metadata returns any metadata that was part of the version
-// string.
-//
-// Metadata is anything that comes after the "+" in the version.
-// For example, with "1.2.3+beta", the metadata is "beta".
-func (v *Version) Metadata() string {
-	return v.metadata
+	return v.Compare(o) <= 0
 }
 
 // Prerelease returns any prerelease data that is part of the version,
@@ -384,8 +523,9 @@ func (v *Version) String() string {
 	return v.original
 }
 
-// String returns the full version string included pre-release
-// and metadata information.
+// NormalizedString returns the canonicalized version string including any
+// pre-release information. Build metadata is not retained, matching Composer,
+// which discards everything after "+" during normalization.
 //
 // This value is rebuilt according to the parsed segments and other
 // information. Therefore, ambiguities in the version string such as
@@ -393,9 +533,17 @@ func (v *Version) String() string {
 // missing parts (1.0 => 1.0.0) will be made into a canonicalized form
 // as shown in the parenthesized examples.
 func (v *Version) NormalizedString() string {
+	if v.branch != "" {
+		return v.branch
+	}
+
 	var buf bytes.Buffer
-	fmtParts := make([]string, len(v.segments))
-	for i, s := range v.segments {
+	segments := v.segments
+	if v.si > 0 && v.si <= len(v.segments) {
+		segments = v.segments[:v.si]
+	}
+	fmtParts := make([]string, len(segments))
+	for i, s := range segments {
 		// We can ignore err here since we've pre-parsed the values in segments
 		str := strconv.FormatInt(s, 10)
 		fmtParts[i] = str
@@ -404,11 +552,17 @@ func (v *Version) NormalizedString() string {
 	if v.pre != "" {
 		fmt.Fprintf(&buf, "-%s", v.pre)
 	}
-	if v.metadata != "" {
-		fmt.Fprintf(&buf, "+%s", v.metadata)
-	}
 
-	return buf.String()
+	result := buf.String()
+	// Re-run the canonical normalizer so the output is a fixed point: a bare
+	// single-segment numeric form (e.g. parsed from "000000") would otherwise
+	// render as "0" yet re-parse to the padded "0.0.0.0", breaking idempotency.
+	// The normalizer is idempotent, so well-formed multi-segment results pass
+	// through unchanged.
+	if normalized, err := normalizeVersion(result); err == nil {
+		return normalized
+	}
+	return result
 }
 
 // Original returns the original parsed version as-is, including any

--- a/version.go
+++ b/version.go
@@ -3,7 +3,6 @@ package version
 import (
 	"bytes"
 	"fmt"
-	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -113,8 +112,10 @@ func Must(v *Version, err error) *Version {
 // If you want boolean results, use the LessThan, Equal,
 // GreaterThan, GreaterThanOrEqual or LessThanOrEqual methods.
 func (v *Version) Compare(other *Version) int {
-	// A quick, efficient equality check
-	if v.NormalizedString() == other.NormalizedString() {
+	// A quick, in-memory equality check. This mirrors comparing the canonical
+	// NormalizedString() of both versions, but avoids re-running the regexp
+	// normalizer (which NormalizedString does) on the hot path.
+	if normalizedEqual(v, other) {
 		return 0
 	}
 
@@ -131,11 +132,13 @@ func (v *Version) Compare(other *Version) int {
 		return 1
 	}
 
-	segmentsSelf := v.Segments64()
-	segmentsOther := other.Segments64()
+	// Read segments directly; we only compare them here, so the defensive copy
+	// from Segments64() is unnecessary.
+	segmentsSelf := v.segments
+	segmentsOther := other.segments
 
 	// If the segments are the same, we must compare on prerelease info
-	if reflect.DeepEqual(segmentsSelf, segmentsOther) {
+	if equalInt64(segmentsSelf, segmentsOther) {
 		preSelf := v.Prerelease()
 		preOther := other.Prerelease()
 		if preSelf == "" && preOther == "" {
@@ -198,6 +201,56 @@ func (v *Version) Compare(other *Version) int {
 
 	// if we got this far, they're equal
 	return 0
+}
+
+// normalizedEqual reports whether two versions have the same canonical form,
+// i.e. whether v.NormalizedString() == other.NormalizedString(), without
+// building or re-normalizing the strings. It must stay in sync with
+// NormalizedString's view of a version: a branch is compared verbatim, and
+// otherwise equality is decided by the prerelease part plus the si-truncated,
+// zero-padded numeric segments.
+func normalizedEqual(v, other *Version) bool {
+	if v.branch != "" || other.branch != "" {
+		// NormalizedString returns the branch string verbatim for branch
+		// versions; a branch and a non-branch are never equal.
+		return v.branch == other.branch
+	}
+	if v.pre != other.pre {
+		return false
+	}
+	return equalInt64(siSegments(v), siSegments(other))
+}
+
+// siSegments returns the segments NormalizedString would render: the first si
+// segments when si is set, otherwise all segments.
+func siSegments(v *Version) []int64 {
+	if v.si > 0 && v.si <= len(v.segments) {
+		return v.segments[:v.si]
+	}
+	return v.segments
+}
+
+// equalInt64 compares two segment slices for equality, treating missing
+// trailing entries as zero (so [1,2] and [1,2,0] are equal). This matches how
+// NormalizedString and Compare treat jagged specificity.
+func equalInt64(a, b []int64) bool {
+	n := len(a)
+	if len(b) > n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		var x, y int64
+		if i < len(a) {
+			x = a[i]
+		}
+		if i < len(b) {
+			y = b[i]
+		}
+		if x != y {
+			return false
+		}
+	}
+	return true
 }
 
 func allZero(segs []int64) bool {

--- a/version_collection.go
+++ b/version_collection.go
@@ -9,9 +9,27 @@ func (v Collection) Len() int {
 }
 
 func (v Collection) Less(i, j int) bool {
-	return v[i].LessThan(v[j])
+	return compareForSort(v[i], v[j]) < 0
 }
 
 func (v Collection) Swap(i, j int) {
 	v[i], v[j] = v[j], v[i]
+}
+
+func compareForSort(left, right *Version) int {
+	return sortVersion(left).Compare(sortVersion(right))
+}
+
+func sortVersion(v *Version) *Version {
+	switch v.branch {
+	case "dev-master", "dev-default", "dev-trunk":
+		return &Version{
+			pre:      "dev",
+			segments: []int64{9999999, 0, 0, 0},
+			si:       1,
+			original: v.original,
+		}
+	default:
+		return v
+	}
 }

--- a/version_test.go
+++ b/version_test.go
@@ -37,8 +37,8 @@ func TestMatchingRCWithTilde(t *testing.T) {
 		}
 	}
 
-	if match != "6.5.0.0-rc1" {
-		t.Errorf("Expected 6.5.0.0-rc1 but got %s", match)
+	if match != "6.5.0.0-RC1" {
+		t.Errorf("Expected 6.5.0.0-RC1 but got %s", match)
 	}
 }
 
@@ -59,8 +59,8 @@ func TestMatchingRCWithCaret(t *testing.T) {
 		}
 	}
 
-	if match != "6.5.0.0-rc1" {
-		t.Errorf("Expected 6.5.0.0-rc1 but got %s", match)
+	if match != "6.5.0.0-RC1" {
+		t.Errorf("Expected 6.5.0.0-RC1 but got %s", match)
 	}
 }
 
@@ -81,8 +81,8 @@ func TestMatchingRCWithCaretThreeNumbers(t *testing.T) {
 		}
 	}
 
-	if match != "6.5.0.0-rc1" {
-		t.Errorf("Expected 6.5.0.0-rc1 but got %s", match)
+	if match != "6.5.0.0-RC1" {
+		t.Errorf("Expected 6.5.0.0-RC1 but got %s", match)
 	}
 }
 
@@ -103,8 +103,8 @@ func TestMatchingRCWithGreaterThanEqual(t *testing.T) {
 		}
 	}
 
-	if match != "6.5.0.0-rc1" {
-		t.Errorf("Expected 6.5.0.0-rc1 but got %s", match)
+	if match != "6.5.0.0-RC1" {
+		t.Errorf("Expected 6.5.0.0-RC1 but got %s", match)
 	}
 }
 
@@ -176,11 +176,11 @@ func TestSortingVersions(t *testing.T) {
 	if vs[2].NormalizedString() != "6.4.8.0" {
 		t.Errorf("Expected 6.4.8.0, got %s", vs[2].NormalizedString())
 	}
-	if vs[3].NormalizedString() != "6.5.0.0-rc1" {
-		t.Errorf("Expected 6.5.0.0-rc1, got %s", vs[3].NormalizedString())
+	if vs[3].NormalizedString() != "6.5.0.0-RC1" {
+		t.Errorf("Expected 6.5.0.0-RC1, got %s", vs[3].NormalizedString())
 	}
-	if vs[4].NormalizedString() != "6.5.0.0-rc2" {
-		t.Errorf("Expected 6.5.0.0-rc2, got %s", vs[4].NormalizedString())
+	if vs[4].NormalizedString() != "6.5.0.0-RC2" {
+		t.Errorf("Expected 6.5.0.0-RC2, got %s", vs[4].NormalizedString())
 	}
 	if vs[5].NormalizedString() != "6.5.0.0" {
 		t.Errorf("Expected 6.5.0.0, got %s", vs[5].NormalizedString())
@@ -462,8 +462,8 @@ func TestConstraintPrerelease(t *testing.T) {
 	}{
 		{"= 1.0", false},
 		{"= 1.0-beta", true},
-		{"~> 2.1.0", false},
-		{"~> 2.1.0-dev", true},
+		{"~ 2.1.0", false},
+		{"~ 2.1.0-dev", true},
 		{"> 2.0", false},
 		{">= 2.1.0-alpha", true},
 	}
@@ -605,31 +605,28 @@ func TestVersionSegments(t *testing.T) {
 	}
 }
 
-func TestVersionMetadata(t *testing.T) {
+// TestVersionBuildMetadata verifies that build metadata is stripped during
+// normalization (matching Composer, which discards everything after "+") while
+// any pre-release part is still parsed correctly.
+func TestVersionBuildMetadata(t *testing.T) {
 	tests := []struct {
-		version          string
-		expectedMetadata string
-		expectedPre      string
-		isPrerelease     bool
+		version      string
+		expectedPre  string
+		isPrerelease bool
 	}{
-		{"1.2.3", "", "", false},
-		{"1.2.3+build", "", "", false},
-		{"1.2.3-beta", "", "beta", true},
-		{"1.2.3-beta+build", "", "beta", true},
-		{"1.2.3+build.1", "", "", false},
-		{"1.2.3-beta1+build.1", "", "beta1", true},
-		{"1.2.3-alpha1+build.123.4", "", "alpha1", true},
+		{"1.2.3", "", false},
+		{"1.2.3+build", "", false},
+		{"1.2.3-beta", "beta", true},
+		{"1.2.3-beta+build", "beta", true},
+		{"1.2.3+build.1", "", false},
+		{"1.2.3-beta1+build.1", "beta1", true},
+		{"1.2.3-alpha1+build.123.4", "alpha1", true},
 	}
 
 	for _, tc := range tests {
 		v := Must(NewVersion(tc.version))
-		metadata := v.Metadata()
 		prerelease := v.Prerelease()
 		isPrerelease := v.IsPrerelease()
-
-		if metadata != tc.expectedMetadata {
-			t.Errorf("Expected metadata %s, got %s for version %s", tc.expectedMetadata, metadata, tc.version)
-		}
 
 		if prerelease != tc.expectedPre {
 			t.Errorf("Expected prerelease %s, got %s for version %s", tc.expectedPre, prerelease, tc.version)


### PR DESCRIPTION
## Summary

Adds a Composer-compatible **constraint domain algebra** (`ConstraintIntersects` / `ConstraintSubsetOf`) plus a set of correctness, safety, and tooling improvements. All behavior was verified against the real `composer/semver` (v3.4) where applicable.

## Features
- **`ConstraintIntersects` / `ConstraintSubsetOf`** — domain-based intersection and subset checks for Composer constraints (interval + branch model).
- **`Satisfies`**, **`NormalizeComposerVersion`**, **`Stability`** helper APIs.
- dev-branch handling and patch-aware prerelease ranking in `Compare`.

## Fixes
- **`@stable` flag now matches Composer.** It is stripped and discarded rather than treated as a `-stable` modifier, so `>=1.0@stable` behaves like `>=1.0` (an explicit `-stable` *modifier* is still honored). Verified: `satisfies("1.0.0-beta", ">=1.0@stable") = true`, matching Composer.
- **Panic on non-UTF-8 version input** (e.g. byte `\x95`) — found by fuzzing. Error-message regexes are now compiled defensively (`regexp.Compile`) instead of `regexp.MustCompile`, so junk input returns an error instead of crashing.
- **Non-idempotent `NormalizedString`** for all-zero multi-digit input — found by fuzzing. `"000000"` now canonicalizes to `"0.0.0.0"`, consistent with `"0"`.
- **Removed dead `Metadata()` API.** Build metadata is stripped during normalization (matching Composer, which discards everything after `+`), so the accessor could never return a value. *(Breaking: `Version.Metadata()` is gone.)*

## Tests & tooling
- **Native Go fuzz targets** for every untrusted-input entry point (`NewVersion`, `NewConstraint`, `NormalizeComposerVersion`, `Satisfies`, `ConstraintIntersects`), with a committed regression corpus under `testdata/`.
- **CI**: added `go vet`, the race detector, and a bounded fuzz smoke run; bumped actions to latest majors; added a `go` directive to `go.mod`.

## Refactor
- Split the 1,187-line `intersect.go` into `domain.go`, `interval.go`, and `snapshot.go` within the same package — **no API or behavior change**.

## Verification
`go build`, `go vet`, `go test -race`, and all five fuzz targets pass.

> Note: this PR also bundles prior uncommitted work in the tree (the intersect feature, branch handling, prerelease ranking) that was intermingled with the above and could not be cleanly separated.